### PR TITLE
(#1954429) rc-local: order after network-online.target

### DIFF
--- a/units/rc-local.service.in
+++ b/units/rc-local.service.in
@@ -13,7 +13,8 @@
 Description={{RC_LOCAL_PATH}} Compatibility
 Documentation=man:systemd-rc-local-generator(8)
 ConditionFileIsExecutable={{RC_LOCAL_PATH}}
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
I think this was the intent of commit 91b684c7300879a8d2006038f7d9185d92c3c3bf,
just network-online.target didn't exist back then.

RHEL-only

Resolves: #1954429