### PR TITLE
(#1997200) pid1: bump DefaultTasksMax to 80% of the kernel pid.max value

### DIFF
--- a/man/systemd-system.conf.xml
+++ b/man/systemd-system.conf.xml
@@ -389,10 +389,10 @@
         <listitem><para>Configure the default value for the per-unit <varname>TasksMax=</varname> setting. See
         <citerefentry><refentrytitle>systemd.resource-control</refentrytitle><manvolnum>5</manvolnum></citerefentry>
         for details. This setting applies to all unit types that support resource control settings, with the exception
-        of slice units. Defaults to 15% of the minimum of <varname>kernel.pid_max=</varname>, <varname>kernel.threads-max=</varname>
+        of slice units. Defaults to 80% of the minimum of <varname>kernel.pid_max=</varname>, <varname>kernel.threads-max=</varname>
         and root cgroup <varname>pids.max</varname>.
         Kernel has a default value for <varname>kernel.pid_max=</varname> and an algorithm of counting in case of more than 32 cores.
-        For example with the default <varname>kernel.pid_max=</varname>, <varname>DefaultTasksMax=</varname> defaults to 4915,
+        For example with the default <varname>kernel.pid_max=</varname>, <varname>DefaultTasksMax=</varname> defaults to 26214,
         but might be greater in other systems or smaller in OS containers.</para></listitem>
       </varlistentry>
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -92,7 +92,7 @@
 #include <sanitizer/lsan_interface.h>
 #endif
 
-#define DEFAULT_TASKS_MAX ((TasksMax) { 15U, 100U }) /* 15% */
+#define DEFAULT_TASKS_MAX ((TasksMax) { 80U, 100U }) /* 80% */
 
 static enum {
         ACTION_RUN,

--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -54,7 +54,7 @@
 #DefaultBlockIOAccounting=no
 #DefaultMemoryAccounting={{ 'yes' if MEMORY_ACCOUNTING_DEFAULT else 'no' }}
 #DefaultTasksAccounting=yes
-#DefaultTasksMax=15%
+#DefaultTasksMax=80%
 #DefaultLimitCPU=
 #DefaultLimitFSIZE=
 #DefaultLimitDATA=


### PR DESCRIPTION
This should be hopefully high enough even for the very big deployments.

Resolves: #1997200