### PR TITLE
(#1921094) udev/net-setup-link: change the default MACAddressPolicy to "none"

### DIFF
--- a/man/systemd.link.xml
+++ b/man/systemd.link.xml
@@ -816,7 +816,7 @@
 
       <programlisting>[Link]
 NamePolicy=kernel database onboard slot path
-MACAddressPolicy=persistent</programlisting>
+MACAddressPolicy=none</programlisting>
     </example>
 
     <example>

--- a/test/fuzz/fuzz-link-parser/99-default.link
+++ b/test/fuzz/fuzz-link-parser/99-default.link
@@ -9,4 +9,4 @@
 
 [Link]
 NamePolicy=keep kernel database onboard slot path
-MACAddressPolicy=persistent
+MACAddressPolicy=none


### PR DESCRIPTION
While stable MAC address for interface types that don't have the
address provided by HW could be useful it also breaks LACP based bonds.
Let's err on the side of caution and don't change the MAC address from
udev.

Resolves: #1921094