### PR TITLE
(#1972223)  unit: install the systemd-bless-boot.service only if we have gnu-efi

### DIFF
--- a/units/meson.build
+++ b/units/meson.build
@@ -179,7 +179,7 @@ in_units = [
         ['systemd-backlight@.service',           'ENABLE_BACKLIGHT'],
         ['systemd-binfmt.service',               'ENABLE_BINFMT',
          'sysinit.target.wants/'],
-        ['systemd-bless-boot.service',           'ENABLE_EFI HAVE_BLKID'],
+        ['systemd-bless-boot.service',           'HAVE_GNU_EFI HAVE_BLKID'],
         ['systemd-boot-check-no-failures.service', ''],
         ['systemd-coredump@.service',            'ENABLE_COREDUMP'],
         ['systemd-pstore.service',               'ENABLE_PSTORE'],


### PR DESCRIPTION
Follow-up to #20591.

(cherry picked from commit 220261ef940a126588b20a1765a2501811473839)

Related: #1972223