### PR TITLE
(#1921094) udev/net-setup-link: *really* change the default MACAddressPolicy to "none"

### DIFF
--- a/network/99-default.link
+++ b/network/99-default.link
@@ -13,4 +13,4 @@ OriginalName=*
 [Link]
 NamePolicy=keep kernel database onboard slot path
 AlternativeNamesPolicy=database onboard slot path
-MACAddressPolicy=persistent
+MACAddressPolicy=none


### PR DESCRIPTION
Fix the oversight and change the policy in the link file, i.e. the
place where it actually matters.

Related: #1921094