### PR TITLE
(#2017035) test: don't install test-network-generator-conversion.sh w/o networkd

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -98,9 +98,12 @@ if install_tests
         install_data('run-unit-tests.py',
                      install_mode : 'rwxr-xr-x',
                      install_dir : testsdir)
-        install_data('test-network-generator-conversion.sh',
-                     install_mode : 'rwxr-xr-x',
-                     install_dir : testsdir)
+
+        if conf.get('ENABLE_NETWORKD') == 1
+                install_data('test-network-generator-conversion.sh',
+                             install_mode : 'rwxr-xr-x',
+                             install_dir : testsdir)
+        endif
 endif
 
 ############################################################


### PR DESCRIPTION
otherwise TEST-02 will fail:

```
=== Failed test log ===
--- test-network-generator-conversion.sh begin ---
+ [[ -n '' ]]
+ [[ -x /usr/lib/systemd/systemd-network-generator ]]
+ [[ -x /lib/systemd/systemd-network-generator ]]
+ exit 1
--- test-network-generator-conversion.sh end ---
```

Before:
```
$ meson build -Dnetworkd=false -Dinstall-tests=true
$ ninja -C build
$ DESTDIR=$PWD/test-install ninja -C build install
$ find test-install/ -name test-network-generator-conversion.sh
test-install/usr/lib/systemd/tests/test-network-generator-conversion.sh
```

After:
```
$ find test-install/ -name test-network-generator-conversion.sh
<no output>
```

(cherry picked from commit 140557021ad1a3946319fff1a87831eb02d6a1a0)

Related: #2017035