### PR TITLE
(#2019468) core/mount: add implicit unit dependencies even if when mount unit is…

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1582,6 +1582,10 @@ static int mount_setup_new_unit(
         if (r < 0)
                 return r;
 
+        r = mount_add_non_exec_dependencies(MOUNT(u));
+        if (r < 0)
+                return r;
+
         /* This unit was generated because /proc/self/mountinfo reported it. Remember this, so that by the time we load
          * the unit file for it (and thus add in extra deps right after) we know what source to attributes the deps
          * to. */


### PR DESCRIPTION
… generated from /proc/self/mountinfo

Hopefully fixes #20566.

(cherry picked from commit aebff2e7ce209fc2d75b894a3ae8b80f6f36ec11)

Resolves: #2019468