### PR TITLE
(#2017035) ci: use C9S chroots in Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -37,9 +37,8 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-      # FIXME: change to CentOS 9 once it's available
-      - fedora-34-x86_64
-      - fedora-34-aarch64
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
 
 # TODO: can't use TFT yet due to https://pagure.io/fedora-ci/general/issue/184
 # Run tests (via testing farm)


### PR DESCRIPTION
rhel-only
Related: #2017035