### PR TITLE
Treat EPERM as "not available" too

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -3780,7 +3780,7 @@ static int outer_child(
             arg_uid_shift != 0) {
 
                 r = remount_idmap(directory, arg_uid_shift, arg_uid_range);
-                if (r == -EINVAL || ERRNO_IS_NOT_SUPPORTED(r)) {
+                if (IN_SET(r, -EINVAL, -EPERM) || ERRNO_IS_NOT_SUPPORTED(r)) {
                         /* This might fail because the kernel or file system doesn't support idmapping. We
                          * can't really distinguish this nicely, nor do we have any guarantees about the
                          * error codes we see, could be EOPNOTSUPP or EINVAL. */

--- a/test/test-functions
+++ b/test/test-functions
@@ -1151,6 +1151,17 @@ install_systemd() {
         mkdir -p "$initdir/etc/systemd/system/service.d/"
         echo -e "[Service]\nProtectSystem=no\nProtectHome=no\n" >"$initdir/etc/systemd/system/service.d/gcov-override.conf"
     fi
+
+    # If we're built with -Dportabled=false, tests with systemd-analyze
+    # --profile will fail. Since we need just the profile (text) files, let's
+    # copy them into the image if they don't exist there.
+    local portable_dir="${initdir:?}${ROOTLIBDIR:?}/portable"
+    if [[ ! -d "$portable_dir/profile/strict" ]]; then
+        dinfo "Couldn't find portable profiles in the test image"
+        dinfo "Copying them directly from the source tree"
+        mkdir -p "$portable_dir"
+        cp -frv "${SOURCE_DIR:?}/src/portable/profile" "$portable_dir"
+    fi
 }
 
 get_ldpath() {


### PR DESCRIPTION
We need to do this because idmapped mounts have been disabled in RHEL-9
kernel: https://bugzilla.redhat.com/show_bug.cgi?id=2018141 .

RHEL-only

Fixes #55

Related: #2017035