### PR TITLE
(#2005367) meson: extends putting extra net naming schemes together

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -725,11 +725,20 @@ foreach scheme: get_option('extra-net-naming-schemes').split(',')
                 name = scheme.split('=')[0]
                 value = scheme.split('=')[1]
                 NAME = name.underscorify().to_upper()
-                VALUE = []
+                ENABLED_SCHEMAS = []
+                DISABLED_SCHEMAS = []
                 foreach field: value.split('+')
-                        VALUE += 'NAMING_' + field.underscorify().to_upper()
+                        if field.startswith('-')
+                                DISABLED_SCHEMAS += 'NAMING_' + field.substring(1).underscorify().to_upper()
+                        else
+                                ENABLED_SCHEMAS += 'NAMING_' + field.underscorify().to_upper()
+                        endif
                 endforeach
-                extra_net_naming_schemes += 'NAMING_@0@ = @1@,'.format(NAME, '|'.join(VALUE))
+                extra_net_naming_schemes += 'NAMING_@0@ = @1@'.format(NAME, '|'.join(ENABLED_SCHEMAS))
+                foreach disabled: DISABLED_SCHEMAS
+                        extra_net_naming_schemes += ' & ~@0@'.format(disabled)
+                endforeach
+                extra_net_naming_schemes += ','
                 extra_net_naming_map += '{ "@0@", NAMING_@1@ },'.format(name, NAME)
         endif
 endforeach


### PR DESCRIPTION
In downstream, we define custom combinations and sometimes it is handy to rely
on some already defined set to alias it or to append something on top of it.
It is not possible however to toggle (disable) schema out of such set.

With this patch meson extra-net-naming-schemes can be provided with negative
values, like:

$ meson configure build \
  -Dextra-net-naming-schemes=gargoyle=v239+-slot_function_id+-16bit_index+-replace_strictly
It will yield:
NAMING_GARGOYLE = NAMING_V239 & ~NAMING_SLOT_FUNCTION_ID & ~NAMING_16BIT_INDEX \
  & ~NAMING_REPLACE_STRICTLY

That would effectively drag naming schema from v249, back to v247.

Combining positive and negative values is also valid:

$ meson configure build \
  -Dextra-net-naming-schemes=gargoyle=v241+nspawn_long_hash+-label_noprefix
It will yield:
NAMING_GARGOYLE = NAMING_V241|NAMING_NSPAWN_LONG_HASH & ~NAMING_LABEL_NOPREFIX

It is worth to mention that positive values will be grouped first (and ORed) and then
negative values together (and each one NOTed and ANDed).

Follow up on dist-git would be to specify:
`-Dextra-net-naming-schemes=rhel_9_0=v249+-replace_strictly -Ddefault-net-naming-scheme=rhel_9_0`
that would yield:
#define EXTRA_NET_NAMING_MAP { "rhel_9_0", NAMING_RHEL_9_0 },
#define EXTRA_NET_NAMING_SCHEMES NAMING_RHEL_9_0 = NAMING_V249  & ~NAMING_REPLACE_STRICTLY ,