### PR TITLE
(#2047768) test: require unified cgroup hierarchy for TEST-56 

### DIFF
--- a/test/TEST-56-EXIT-TYPE/test.sh
+++ b/test/TEST-56-EXIT-TYPE/test.sh
@@ -6,4 +6,9 @@ TEST_DESCRIPTION="test ExitType=cgroup"
 # shellcheck source=test/test-functions
 . "${TEST_BASE_DIR:?}/test-functions"
 
+if [[ "$(get_cgroup_hierarchy)" != unified ]]; then
+    echo "This test requires unified cgroup hierarchy, skipping..."
+    exit 0
+fi
+
 do_test "$@"

--- a/test/test-functions
+++ b/test/test-functions
@@ -1996,6 +1996,24 @@ import_initdir() {
     export initdir
 }
 
+get_cgroup_hierarchy() {
+    case "$(stat -c '%T' -f /sys/fs/cgroup)" in
+        cgroup2fs)
+            echo "unified"
+            ;;
+        tmpfs)
+            if [[ -d /sys/fs/cgroup/unified && "$(stat -c '%T' -f /sys/fs/cgroup/unified)" == cgroup2fs ]]; then
+                echo "hybrid"
+            else
+                echo "legacy"
+            fi
+            ;;
+        *)
+            dfatal "Failed to determine host's cgroup hierarchy"
+            exit 1
+    esac
+}
+
 ## @brief Converts numeric logging level to the first letter of level name.
 #
 # @param lvl Numeric logging level in range from 1 to 6.


### PR DESCRIPTION
since cgroup empty notifications are unreliable in legacy cgroups.

See: systemd/systemd#22320
Complements: systemd/systemd#22344
(cherry picked from commit e2620820188428de7086f5e8ac41305177f70954)

Related: #2047768
