### PR TITLE
(#2017035) tests: rework test macros to not take code as parameters

### DIFF
--- a/src/shared/tests.h
+++ b/src/shared/tests.h
@@ -110,27 +110,28 @@ static inline int run_test_table(void) {
         return r;
 }
 
-static inline int test_nop(void) {
-        return EXIT_SUCCESS;
-}
-
-#define DEFINE_CUSTOM_TEST_MAIN(log_level, intro, outro) \
-        int main(int argc, char *argv[]) {               \
-                int _r, _q;                              \
-                test_setup_logging(log_level);           \
-                save_argc_argv(argc, argv);              \
-                _r = intro();                            \
-                if (_r == EXIT_SUCCESS)                  \
-                        _r = run_test_table();           \
-                _q = outro();                            \
-                static_destruct();                       \
-                if (_r < 0)                              \
-                        return EXIT_FAILURE;             \
-                if (_r != EXIT_SUCCESS)                  \
-                        return _r;                       \
-                if (_q < 0)                              \
-                        return EXIT_FAILURE;             \
-                return _q;                               \
+#define DEFINE_TEST_MAIN_FULL(log_level, intro, outro)    \
+        int main(int argc, char *argv[]) {                \
+                int (*_intro)(void) = intro;              \
+                int (*_outro)(void) = outro;              \
+                int _r, _q;                               \
+                test_setup_logging(log_level);            \
+                save_argc_argv(argc, argv);               \
+                _r = _intro ? _intro() : EXIT_SUCCESS;    \
+                if (_r == EXIT_SUCCESS)                   \
+                        _r = run_test_table();            \
+                _q = _outro ? _outro() : EXIT_SUCCESS;    \
+                static_destruct();                        \
+                if (_r < 0)                               \
+                        return EXIT_FAILURE;              \
+                if (_r != EXIT_SUCCESS)                   \
+                        return _r;                        \
+                if (_q < 0)                               \
+                        return EXIT_FAILURE;              \
+                return _q;                                \
         }
 
-#define DEFINE_TEST_MAIN(log_level) DEFINE_CUSTOM_TEST_MAIN(log_level, test_nop, test_nop)
+#define DEFINE_TEST_MAIN_WITH_INTRO(log_level, intro)   \
+        DEFINE_TEST_MAIN_FULL(log_level, intro, NULL)
+#define DEFINE_TEST_MAIN(log_level)                     \
+        DEFINE_TEST_MAIN_FULL(log_level, NULL, NULL)

--- a/src/test/test-barrier.c
+++ b/src/test/test-barrier.c
@@ -444,4 +444,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
  }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-barrier.c
+++ b/src/test/test-barrier.c
@@ -421,25 +421,27 @@ TEST_BARRIER(barrier_pending_exit,
         }),
         TEST_BARRIER_WAIT_SUCCESS(pid2));
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_INFO,
-        ({
-                if (!slow_tests_enabled())
-                        return log_tests_skipped("slow tests are disabled");
 
-                /*
-                * This test uses real-time alarms and sleeps to test for CPU races
-                * explicitly. This is highly fragile if your system is under load. We
-                * already increased the BASE_TIME value to make the tests more robust,
-                * but that just makes the test take significantly longer. Given the recent
-                * issues when running the test in a virtualized environments, limit it
-                * to bare metal machines only, to minimize false-positives in CIs.
-                */
-                int v = detect_virtualization();
-                if (IN_SET(v, -EPERM, -EACCES))
-                        return log_tests_skipped("Cannot detect virtualization");
+static int intro(void) {
+        if (!slow_tests_enabled())
+                return log_tests_skipped("slow tests are disabled");
 
-                if (v != VIRTUALIZATION_NONE)
-                        return log_tests_skipped("This test requires a baremetal machine");
-        }),
-        /* no outro */);
+        /*
+         * This test uses real-time alarms and sleeps to test for CPU races explicitly. This is highly
+         * fragile if your system is under load. We already increased the BASE_TIME value to make the tests
+         * more robust, but that just makes the test take significantly longer. Given the recent issues when
+         * running the test in a virtualized environments, limit it to bare metal machines only, to minimize
+         * false-positives in CIs.
+         */
+
+        int v = detect_virtualization();
+        if (IN_SET(v, -EPERM, -EACCES))
+                return log_tests_skipped("Cannot detect virtualization");
+
+        if (v != VIRTUALIZATION_NONE)
+                return log_tests_skipped("This test requires a baremetal machine");
+
+        return EXIT_SUCCESS;
+ }
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-cgroup-setup.c
+++ b/src/test/test-cgroup-setup.c
@@ -64,10 +64,11 @@ TEST(is_wanted) {
         test_is_wanted_print_one(false);
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_DEBUG,
-        ({
-                if (access("/proc/cmdline", R_OK) < 0 && ERRNO_IS_PRIVILEGE(errno))
-                        return log_tests_skipped("can't read /proc/cmdline");
-        }),
-        /* no outro */);
+static int intro(void) {
+        if (access("/proc/cmdline", R_OK) < 0 && ERRNO_IS_PRIVILEGE(errno))
+                return log_tests_skipped("can't read /proc/cmdline");
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);

--- a/src/test/test-cgroup-setup.c
+++ b/src/test/test-cgroup-setup.c
@@ -71,4 +71,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);

--- a/src/test/test-chown-rec.c
+++ b/src/test/test-chown-rec.c
@@ -156,4 +156,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);

--- a/src/test/test-chown-rec.c
+++ b/src/test/test-chown-rec.c
@@ -149,10 +149,11 @@ TEST(chown_recursive) {
         assert_se(!has_xattr(p));
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_DEBUG,
-        ({
-                if (geteuid() != 0)
-                        return log_tests_skipped("not running as root");
-        }),
-        /* no outro */);
+static int intro(void) {
+        if (geteuid() != 0)
+                return log_tests_skipped("not running as root");
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);

--- a/src/test/test-format-table.c
+++ b/src/test/test-format-table.c
@@ -535,4 +535,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-format-table.c
+++ b/src/test/test-format-table.c
@@ -529,10 +529,10 @@ TEST(table) {
                                 "5min              5min              \n"));
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_INFO,
-        ({
-                assert_se(setenv("SYSTEMD_COLORS", "0", 1) >= 0);
-                assert_se(setenv("COLUMNS", "40", 1) >= 0);
-        }),
-        /* no outro */);
+static int intro(void) {
+        assert_se(setenv("SYSTEMD_COLORS", "0", 1) >= 0);
+        assert_se(setenv("COLUMNS", "40", 1) >= 0);
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -973,4 +973,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -968,4 +968,9 @@ TEST(open_mkdir_at) {
         assert_se(subsubdir_fd >= 0);
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, arg_test_dir = argv[1], /* no outro */);
+static int intro(void) {
+        arg_test_dir = saved_argv[1];
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-hashmap.c
+++ b/src/test/test-hashmap.c
@@ -169,4 +169,4 @@ static int outro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, outro);
+DEFINE_TEST_MAIN_FULL(LOG_INFO, intro, outro);

--- a/src/test/test-hashmap.c
+++ b/src/test/test-hashmap.c
@@ -158,7 +158,15 @@ TEST(hashmap_put_strdup_null) {
 /* This variable allows us to assert that the tests from different compilation units were actually run. */
 int n_extern_tests_run = 0;
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_INFO,
-        assert_se(n_extern_tests_run == 0),
-        assert_se(n_extern_tests_run == 2)); /* Ensure hashmap and ordered_hashmap were tested. */
+static int intro(void) {
+        assert_se(n_extern_tests_run == 0);
+        return EXIT_SUCCESS;
+}
+
+static int outro(void) {
+        /* Ensure hashmap and ordered_hashmap were tested. */
+        assert_se(n_extern_tests_run == 2);
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, outro);

--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -1272,4 +1272,4 @@ static int intro(void) {
 }
 
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-load-fragment.c
+++ b/src/test/test-load-fragment.c
@@ -906,4 +906,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-load-fragment.c
+++ b/src/test/test-load-fragment.c
@@ -30,6 +30,10 @@
 /* Nontrivial value serves as a placeholder to check that parsing function (didn't) change it */
 #define CGROUP_LIMIT_DUMMY      3
 
+static char *runtime_dir = NULL;
+
+STATIC_DESTRUCTOR_REGISTER(runtime_dir, rm_rf_physical_and_freep);
+
 TEST_RET(unit_file_get_set) {
         int r;
         Hashmap *h;
@@ -894,15 +898,12 @@ TEST(unit_is_recursive_template_dependency) {
         assert_se(unit_is_likely_recursive_template_dependency(u, "foobar@foobar@123.mount", "foobar@%n.mount") == 0);
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_INFO,
+static int intro(void) {
+        if (enter_cgroup_subroot(NULL) == -ENOMEDIUM)
+                return log_tests_skipped("cgroupfs not available");
 
-        _cleanup_(rm_rf_physical_and_freep) char *runtime_dir = NULL;
-        ({
-                if (enter_cgroup_subroot(NULL) == -ENOMEDIUM)
-                        return log_tests_skipped("cgroupfs not available");
+        assert_se(runtime_dir = setup_fake_runtime_dir());
+        return EXIT_SUCCESS;
+}
 
-                assert_se(runtime_dir = setup_fake_runtime_dir());
-        }),
-
-        /* no outro */);
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-mountpoint-util.c
+++ b/src/test/test-mountpoint-util.c
@@ -313,4 +313,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);

--- a/src/test/test-mountpoint-util.c
+++ b/src/test/test-mountpoint-util.c
@@ -298,17 +298,19 @@ TEST(fd_is_mount_point) {
         assert_se(IN_SET(fd_is_mount_point(fd, "root/", 0), -ENOENT, 0));
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_DEBUG,
-        ({
-                /* let's move into our own mount namespace with all propagation from the host turned off, so
-                 * that /proc/self/mountinfo is static and constant for the whole time our test runs. */
-                if (unshare(CLONE_NEWNS) < 0) {
-                        if (!ERRNO_IS_PRIVILEGE(errno))
-                                return log_error_errno(errno, "Failed to detach mount namespace: %m");
+static int intro(void) {
+        /* let's move into our own mount namespace with all propagation from the host turned off, so
+         * that /proc/self/mountinfo is static and constant for the whole time our test runs. */
 
-                        log_notice("Lacking privilege to create separate mount namespace, proceeding in originating mount namespace.");
-                } else
-                        assert_se(mount(NULL, "/", NULL, MS_PRIVATE | MS_REC, NULL) >= 0);
-        }),
-        /* no outro */);
+        if (unshare(CLONE_NEWNS) < 0) {
+                if (!ERRNO_IS_PRIVILEGE(errno))
+                        return log_error_errno(errno, "Failed to detach mount namespace: %m");
+
+                log_notice("Lacking privilege to create separate mount namespace, proceeding in originating mount namespace.");
+        } else
+                assert_se(mount(NULL, "/", NULL, MS_PRIVATE | MS_REC, NULL) >= 0);
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);

--- a/src/test/test-namespace.c
+++ b/src/test/test-namespace.c
@@ -220,10 +220,11 @@ TEST(protect_kernel_logs) {
         assert_se(wait_for_terminate_and_check("ns-kernellogs", pid, WAIT_LOG) == EXIT_SUCCESS);
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_INFO,
-        ({
-                if (!have_namespaces())
-                        return log_tests_skipped("Don't have namespace support");
-        }),
-        /* no outro */);
+static int intro(void) {
+        if (!have_namespaces())
+                return log_tests_skipped("Don't have namespace support");
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-namespace.c
+++ b/src/test/test-namespace.c
@@ -227,4 +227,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-proc-cmdline.c
+++ b/src/test/test-proc-cmdline.c
@@ -247,10 +247,11 @@ TEST(proc_cmdline_key_startswith) {
         assert_se(!proc_cmdline_key_startswith("foo-bar", "foo_xx"));
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_INFO,
-        ({
-                if (access("/proc/cmdline", R_OK) < 0 && ERRNO_IS_PRIVILEGE(errno))
-                        return log_tests_skipped("can't read /proc/cmdline");
-        }),
-        /* no outro */);
+static int intro(void) {
+        if (access("/proc/cmdline", R_OK) < 0 && ERRNO_IS_PRIVILEGE(errno))
+                return log_tests_skipped("can't read /proc/cmdline");
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-proc-cmdline.c
+++ b/src/test/test-proc-cmdline.c
@@ -254,4 +254,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-process-util.c
+++ b/src/test/test-process-util.c
@@ -900,4 +900,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-process-util.c
+++ b/src/test/test-process-util.c
@@ -895,4 +895,9 @@ TEST(set_oom_score_adjust) {
         assert_se(b == a);
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, log_show_color(true), /* no outro */);
+static int intro(void) {
+        log_show_color(true);
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-sd-hwdb.c
+++ b/src/test/test-sd-hwdb.c
@@ -63,4 +63,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);

--- a/src/test/test-sd-hwdb.c
+++ b/src/test/test-sd-hwdb.c
@@ -52,12 +52,15 @@ TEST(basic_enumerate) {
         assert_se(len1 == len2);
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_DEBUG,
-        ({
-                _cleanup_(sd_hwdb_unrefp) sd_hwdb *hwdb = NULL;
-                int r = sd_hwdb_new(&hwdb);
-                if (r == -ENOENT || ERRNO_IS_PRIVILEGE(r))
-                        return log_tests_skipped_errno(r, "cannot open hwdb");
-        }),
-        /* no outro */);
+static int intro(void) {
+        _cleanup_(sd_hwdb_unrefp) sd_hwdb *hwdb = NULL;
+        int r;
+
+        r = sd_hwdb_new(&hwdb);
+        if (r == -ENOENT || ERRNO_IS_PRIVILEGE(r))
+                return log_tests_skipped_errno(r, "cannot open hwdb");
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);

--- a/src/test/test-serialize.c
+++ b/src/test/test-serialize.c
@@ -195,4 +195,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-serialize.c
+++ b/src/test/test-serialize.c
@@ -10,7 +10,7 @@
 #include "tests.h"
 #include "tmpfile-util.h"
 
-char long_string[LONG_LINE_MAX+1];
+static char long_string[LONG_LINE_MAX+1];
 
 TEST(serialize_item) {
         _cleanup_(unlink_tempfilep) char fn[] = "/tmp/test-serialize.XXXXXX";
@@ -189,10 +189,10 @@ TEST(serialize_environment) {
         assert_se(strv_equal(env, env2));
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_INFO,
-        ({
-                memset(long_string, 'x', sizeof(long_string)-1);
-                char_array_0(long_string);
-        }),
-        /* no outro */);
+static int intro(void) {
+        memset(long_string, 'x', sizeof(long_string)-1);
+        char_array_0(long_string);
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-sleep.c
+++ b/src/test/test-sleep.c
@@ -118,10 +118,11 @@ TEST(sleep) {
         log_info("Suspend-then-Hibernate configured and possible: %s", r >= 0 ? yes_no(r) : strerror_safe(r));
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_DEBUG,
-        ({
-                if (getuid() != 0)
-                        log_warning("This program is unlikely to work for unprivileged users");
-        }),
-        /* no outro */);
+static int intro(void) {
+        if (getuid() != 0)
+                log_warning("This program is unlikely to work for unprivileged users");
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);

--- a/src/test/test-sleep.c
+++ b/src/test/test-sleep.c
@@ -125,4 +125,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);

--- a/src/test/test-stat-util.c
+++ b/src/test/test-stat-util.c
@@ -236,4 +236,9 @@ TEST(dir_is_empty) {
         assert_se(dir_is_empty_at(AT_FDCWD, empty_dir) > 0);
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, log_show_color(true), /* no outro */);
+static int intro(void) {
+        log_show_color(true);
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-stat-util.c
+++ b/src/test/test-stat-util.c
@@ -241,4 +241,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-time-util.c
+++ b/src/test/test-time-util.c
@@ -588,7 +588,7 @@ TEST(map_clock_usec) {
         }
 }
 
-static void setup_test(void) {
+static int intro(void) {
         log_info("realtime=" USEC_FMT "\n"
                  "monotonic=" USEC_FMT "\n"
                  "boottime=" USEC_FMT "\n",
@@ -603,6 +603,8 @@ static void setup_test(void) {
         uintmax_t x = TIME_T_MAX;
         x++;
         assert_se((time_t) x < 0);
+
+        return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, setup_test(), /* no outro */);
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-time-util.c
+++ b/src/test/test-time-util.c
@@ -607,4 +607,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-unit-file.c
+++ b/src/test/test-unit-file.c
@@ -102,4 +102,9 @@ TEST(runlevel_to_target) {
         assert_se(streq_ptr(runlevel_to_target("rd.rescue"), SPECIAL_RESCUE_TARGET));
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, log_show_color(true), /* no outro */);
+static int intro(void) {
+        log_show_color(true);
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);

--- a/src/test/test-unit-file.c
+++ b/src/test/test-unit-file.c
@@ -107,4 +107,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);

--- a/src/test/test-unit-name.c
+++ b/src/test/test-unit-name.c
@@ -856,4 +856,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);

--- a/src/test/test-unit-serialize.c
+++ b/src/test/test-unit-serialize.c
@@ -60,4 +60,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);

--- a/src/test/test-unit-serialize.c
+++ b/src/test/test-unit-serialize.c
@@ -4,6 +4,10 @@
 #include "service.h"
 #include "tests.h"
 
+static char *runtime_dir = NULL;
+
+STATIC_DESTRUCTOR_REGISTER(runtime_dir, rm_rf_physical_and_freep);
+
 #define EXEC_START_ABSOLUTE \
         "ExecStart 0 /bin/sh \"sh\" \"-e\" \"-x\" \"-c\" \"systemctl --state=failed --no-legend --no-pager >/failed ; systemctl daemon-reload ; echo OK >/testok\""
 #define EXEC_START_RELATIVE \
@@ -48,15 +52,12 @@ TEST(deserialize_exec_command) {
         test_deserialize_exec_command_one(m, "control-command", "ExecWhat 11 /a/b c d e", -EINVAL);
 }
 
-DEFINE_CUSTOM_TEST_MAIN(
-        LOG_DEBUG,
+static int intro(void) {
+        if (enter_cgroup_subroot(NULL) == -ENOMEDIUM)
+                return log_tests_skipped("cgroupfs not available");
 
-        _cleanup_(rm_rf_physical_and_freep) char *runtime_dir = NULL;
-        ({
-                if (enter_cgroup_subroot(NULL) == -ENOMEDIUM)
-                        return log_tests_skipped("cgroupfs not available");
+        assert_se(runtime_dir = setup_fake_runtime_dir());
+        return EXIT_SUCCESS;
+}
 
-                assert_se(runtime_dir = setup_fake_runtime_dir());
-        }),
-
-        /* no outro */);
+DEFINE_CUSTOM_TEST_MAIN(LOG_DEBUG, intro, test_nop);

--- a/src/test/test-utf8.c
+++ b/src/test/test-utf8.c
@@ -231,4 +231,9 @@ TEST(utf8_to_utf16) {
         }
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, log_show_color(true), /* no outro */);
+static int intro(void) {
+        log_show_color(true);
+        return EXIT_SUCCESS;
+}
+
+DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);

--- a/src/test/test-utf8.c
+++ b/src/test/test-utf8.c
@@ -236,4 +236,4 @@ static int intro(void) {
         return EXIT_SUCCESS;
 }
 
-DEFINE_CUSTOM_TEST_MAIN(LOG_INFO, intro, test_nop);
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_INFO, intro);


### PR DESCRIPTION
I suspect we'd end up backporting this sooner or later anyway, so let's do it now while it's easy...