### PR TITLE
udev/net-setup-link: change the default MACAddressPolicy to "none"

### DIFF
--- a/man/systemd.link.xml
+++ b/man/systemd.link.xml
@@ -961,7 +961,7 @@
 
       <programlisting>[Link]
 NamePolicy=kernel database onboard slot path
-MACAddressPolicy=persistent</programlisting>
+MACAddressPolicy=none</programlisting>
     </example>
 
     <example>

--- a/network/99-default.link
+++ b/network/99-default.link
@@ -13,4 +13,4 @@ OriginalName=*
 [Link]
 NamePolicy=keep kernel database onboard slot path
 AlternativeNamesPolicy=database onboard slot path
-MACAddressPolicy=persistent
+MACAddressPolicy=none

--- a/test/fuzz/fuzz-link-parser/99-default.link
+++ b/test/fuzz/fuzz-link-parser/99-default.link
@@ -9,4 +9,4 @@
 
 [Link]
 NamePolicy=keep kernel database onboard slot path
-MACAddressPolicy=persistent
+MACAddressPolicy=none


### PR DESCRIPTION
While stable MAC address for interface types that don't have the
address provided by HW could be useful it also breaks LACP based bonds.
Let's err on the side of caution and don't change the MAC address from
udev.

RHEL-only

Resolves: #2009237