### PR TITLE
(#2075987) Backport udev/hwdb support for AV production controllers

### DIFF
--- a/hwdb.d/70-av-production.hwdb
+++ b/hwdb.d/70-av-production.hwdb
@@ -1,0 +1,123 @@
+# This file is part of systemd.
+#
+# Database for AV production controllers that should be accessible to the seat owner.
+#
+# This covers DJ tables, and music-oriented key pads
+#
+# To add local entries, copy this file to
+#   /etc/udev/hwdb.d/
+# and add your rules there. To load the new rules execute (as root):
+#   systemd-hwdb update
+#   udevadm trigger
+
+################
+# Ableton
+################
+# Push 2
+usb:v2982p1967*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+################
+# Eks
+################
+# Otus
+usb:v1157p0300*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+#############################
+# Hercules (Guillemot Corp)
+#############################
+# DJ Console MP3e2
+usb:v06F8pB105*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# DJ Console MP3 LE / Glow
+usb:v06F8pB120*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# DJ Console Mk2
+usb:v06F8pB100*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# DJ Console Mk4
+usb:v06F8pB107*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+#####################
+# Native Instruments
+#####################
+
+# Maschine 2
+usb:v17CCp1140*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Maschine 2 Mikro
+usb:v17CCp1110*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Maschine 2 Studio
+usb:v17CCp1300*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Maschine Jam
+usb:v17CCp1500*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Maschine 3
+usb:v17CCp1600*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol D2
+usb:v17CCp1400*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol F1
+usb:v17CCp1120*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol S2 Mk2
+usb:v17CCp1320*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol S2 Mk3
+usb:v17CCp1710*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol S3
+usb:v17CCp1900*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol S4 Mk2
+usb:v17CCp1310*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol S4 Mk3
+usb:v17CCp1720*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol S5
+usb:v17CCp1420*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol S8
+usb:v17CCp1370*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol X1 Mk2
+usb:v17CCp1220*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol Z1
+usb:v17CCp1210*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Traktor Kontrol Z2
+usb:v17CCp1130*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+####################
+# Pioneer
+####################
+# CDJ 2000 NXS 2
+usb:v2B73p0005*
+ ID_AV_PRODUCTION_CONTROLLER=1

--- a/hwdb.d/70-av-production.hwdb
+++ b/hwdb.d/70-av-production.hwdb
@@ -2,7 +2,8 @@
 #
 # Database for AV production controllers that should be accessible to the seat owner.
 #
-# This covers DJ tables, and music-oriented key pads
+# This covers DJ tables, music-oriented key pads, and streaming-oriented key pads
+# such as Elgato Stream Deck
 #
 # To add local entries, copy this file to
 #   /etc/udev/hwdb.d/
@@ -22,6 +23,29 @@ usb:v2982p1967*
 ################
 # Otus
 usb:v1157p0300*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+################
+# Elgato
+################
+# Stream Deck Original (gen 1)
+usb:v0FD9p0060*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Stream Deck Mini
+usb:v0FD9p0063*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Stream Deck XL
+usb:v0FD9p006C*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Stream Deck Original (gen 2)
+usb:v0FD9p006D*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
+# Stream Deck MK.2
+usb:v0FD9p0080*
  ID_AV_PRODUCTION_CONTROLLER=1
 
 #############################

--- a/hwdb.d/meson.build
+++ b/hwdb.d/meson.build
@@ -28,6 +28,7 @@ hwdb_files_test = files('''
         60-seat.hwdb
         60-sensor.hwdb
         70-analyzers.hwdb
+        70-av-production.hwdb
         70-cameras.hwdb
         70-joystick.hwdb
         70-mouse.hwdb

--- a/hwdb.d/parse_hwdb.py
+++ b/hwdb.d/parse_hwdb.py
@@ -135,6 +135,7 @@ def property_grammar():
              ('MOUSE_WHEEL_CLICK_COUNT', INTEGER),
              ('MOUSE_WHEEL_CLICK_COUNT_HORIZONTAL', INTEGER),
              ('ID_AUTOSUSPEND', Or((Literal('0'), Literal('1')))),
+             ('ID_AV_PRODUCTION_CONTROLLER', Or((Literal('0'), Literal('1')))),
              ('ID_PERSIST', Or((Literal('0'), Literal('1')))),
              ('ID_INPUT', Or((Literal('0'), Literal('1')))),
              ('ID_INPUT_ACCELEROMETER', Or((Literal('0'), Literal('1')))),

--- a/src/login/70-uaccess.rules.in
+++ b/src/login/70-uaccess.rules.in
@@ -87,4 +87,13 @@ ENV{ID_SIGNAL_ANALYZER}=="?*", ENV{DEVTYPE}=="usb_device", TAG+="uaccess"
 # rfkill / radio killswitches
 KERNEL=="rfkill", SUBSYSTEM=="misc", TAG+="uaccess"
 
+# AV production controllers
+# Most of these devices use HID for the knobs, faders, buttons, encoders, and jog wheels.
+SUBSYSTEM=="hidraw", ENV{ID_AV_PRODUCTION_CONTROLLER}=="1", TAG+="uaccess"
+
+# Some devices use vendor defined protocols on USB Bulk endpoints for controllers.
+# Other devices transfer graphics to screens on the device through USB Bulk endpoints.
+# This also allows accessing HID devices with the libusb backend of hidapi.
+SUBSYSTEM=="usb", ENV{ID_AV_PRODUCTION_CONTROLLER}=="1", TAG+="uaccess"
+
 LABEL="uaccess_end"


### PR DESCRIPTION
This backports https://github.com/systemd/systemd/pull/22730 to systemd 250 to allow [Boatswain](https://feaneron.com/2022/03/17/boatswain-your-stream-deck-app-for-linux/) to work properly on RHEL/CentOS 9.

cc: @GeorgesStavracas, @cschalle

Resolves: [rhbz#2075987](https://bugzilla.redhat.com/show_bug.cgi?id=2075987)