### PR TITLE
(#2087677) shutdown: get only active md arrays.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,8 +28,14 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - name: Install build dependencies
-        run: sudo -E .github/workflows/unit_tests.sh SETUP
+        run: |
+          # Drop XDG_* stuff from /etc/environment, so we don't get the user
+          # XDG_* variables when running under sudo
+          sudo sed -i '/^XDG_/d' /etc/environment
+          # Pass only specific env variables through sudo, to avoid having
+          # the already existing XDG_* stuff on the "other side"
+          sudo --preserve-env=CRYPTOLIB,GITHUB_ACTIONS,CI .github/workflows/unit_tests.sh SETUP
       - name: Build & test (${{ matrix.run_phase }}-${{ matrix.cryptolib }})
-        run: sudo -E .github/workflows/unit_tests.sh RUN_${{ matrix.run_phase }}
+        run: sudo --preserve-env=CRYPTOLIB,GITHUB_ACTIONS,CI .github/workflows/unit_tests.sh RUN_${{ matrix.run_phase }}
         env:
           CRYPTOLIB: ${{ matrix.cryptolib }}

--- a/src/shared/bus-unit-util.c
+++ b/src/shared/bus-unit-util.c
@@ -1952,7 +1952,7 @@ static int bus_append_execute_property(sd_bus_message *m, const char *field, con
                         path_simplify(source);
 
                         if (isempty(destination)) {
-                                r = strv_extend(&sources, TAKE_PTR(source));
+                                r = strv_consume(&sources, TAKE_PTR(source));
                                 if (r < 0)
                                         return bus_log_create_error(r);
                         } else {

--- a/test/test-functions
+++ b/test/test-functions
@@ -973,16 +973,19 @@ install_lvm() {
     image_install lvm
     image_install "${ROOTLIBDIR:?}"/system/lvm2-lvmpolld.{service,socket}
     image_install "${ROOTLIBDIR:?}"/system/{blk-availability,lvm2-monitor}.service
-    image_install "${ROOTLIBDIR:?}"/system-generators/lvm2-activation-generator
     image_install -o "/lib/tmpfiles.d/lvm2.conf"
     if get_bool "$LOOKS_LIKE_DEBIAN"; then
         inst_rules 56-lvm.rules 69-lvm-metad.rules
     else
         # Support the new udev autoactivation introduced in lvm 2.03.14
         # https://sourceware.org/git/?p=lvm2.git;a=commit;h=67722b312390cdab29c076c912e14bd739c5c0f6
+        # Static autoactivation (via lvm2-activation-generator) was dropped
+        # in lvm 2.03.15
+        # https://sourceware.org/git/?p=lvm2.git;a=commit;h=ee8fb0310c53ed003a43b324c99cdfd891dd1a7c
         if [[ -f /lib/udev/rules.d/69-dm-lvm.rules ]]; then
             inst_rules 11-dm-lvm.rules 69-dm-lvm.rules
         else
+            image_install "${ROOTLIBDIR:?}"/system-generators/lvm2-activation-generator
             image_install "${ROOTLIBDIR:?}"/system/lvm2-pvscan@.service
             inst_rules 11-dm-lvm.rules 69-dm-lvm-metad.rules
         fi


### PR DESCRIPTION
Current md_list_get() implementation filters all block devices, started from
"md*". This is ambiguous because list could contain:
- partitions created upon md device (mdXpY)
- external metadata container- specific type of md array.

For partitions there is no issue, because they aren't handle STOP_ARRAY
ioctl sent later. It generates misleading errors only.

Second case is more problematic because containers are not locked in kernel.
They are stopped even if container member array is active. For that reason
reboot or shutdown flow could be blocked because metadata manager cannot be
restarted after switch root on shutdown.

Add filters to remove partitions and containers from md_list. Partitions
can be excluded by DEVTYPE. Containers are determined by MD_LEVEL
property, we are excluding all with "container" value.

Signed-off-by: Mariusz Tkaczyk <mariusz.tkaczyk@linux.intel.com>
(cherry picked from commit 3a3b022d2cc112803ea7b9beea98bbcad110368a)

Resolves: #2087677