### PR TITLE
(#2073994) core: command argument can be longer than PATH_MAX

### DIFF
--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -1000,7 +1000,7 @@ int config_parse_exec(
                         if (r < 0)
                                 return ignore ? 0 : -ENOEXEC;
 
-                        r = unit_path_printf(u, word, &resolved);
+                        r = unit_full_printf(u, word, &resolved);
                         if (r < 0) {
                                 log_syntax(unit, ignore ? LOG_WARNING : LOG_ERR, filename, line, r,
                                            "Failed to resolve unit specifiers in %s%s: %m",

--- a/src/test/test-load-fragment.c
+++ b/src/test/test-load-fragment.c
@@ -10,6 +10,7 @@
 #include "capability-util.h"
 #include "conf-parser.h"
 #include "fd-util.h"
+#include "fileio.h"
 #include "format-util.h"
 #include "fs-util.h"
 #include "hashmap.h"
@@ -415,6 +416,21 @@ TEST(config_parse_exec) {
                               &c, u);
         assert_se(r == 0);
         assert_se(c1->command_next == NULL);
+
+        log_info("/* long arg */"); /* See issue #22957. */
+
+        char x[LONG_LINE_MAX-100], *y;
+        y = mempcpy(x, "/bin/echo ", STRLEN("/bin/echo "));
+        memset(y, 'x', sizeof(x) - STRLEN("/bin/echo ") - 1);
+        x[sizeof(x) - 1] = '\0';
+
+        r = config_parse_exec(NULL, "fake", 5, "section", 1,
+                              "LValue", 0, x,
+                              &c, u);
+        assert_se(r >= 0);
+        c1 = c1->command_next;
+        check_execcommand(c1,
+                          "/bin/echo", NULL, y, NULL, false);
 
         log_info("/* empty argument, reset */");
         r = config_parse_exec(NULL, "fake", 4, "section", 1,


### PR DESCRIPTION
Fixes a bug introduced by 065364920281e1cf59cab989e17aff21790505c4.

Fixes #22957.

(cherry picked from commit 58dd4999dcc81a0ed92fbd78bce3592c3e3afe9e)

Resolves: [#2073994](https://bugzilla.redhat.com/show_bug.cgi?id=2073994)