### PR TITLE
(#2087652) ci: limit which env variables we pass through `sudo`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,8 +28,14 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - name: Install build dependencies
-        run: sudo -E .github/workflows/unit_tests.sh SETUP
+        run: |
+          # Drop XDG_* stuff from /etc/environment, so we don't get the user
+          # XDG_* variables when running under sudo
+          sudo sed -i '/^XDG_/d' /etc/environment
+          # Pass only specific env variables through sudo, to avoid having
+          # the already existing XDG_* stuff on the "other side"
+          sudo --preserve-env=CRYPTOLIB,GITHUB_ACTIONS,CI .github/workflows/unit_tests.sh SETUP
       - name: Build & test (${{ matrix.run_phase }}-${{ matrix.cryptolib }})
-        run: sudo -E .github/workflows/unit_tests.sh RUN_${{ matrix.run_phase }}
+        run: sudo --preserve-env=CRYPTOLIB,GITHUB_ACTIONS,CI .github/workflows/unit_tests.sh RUN_${{ matrix.run_phase }}
         env:
           CRYPTOLIB: ${{ matrix.cryptolib }}


### PR DESCRIPTION
to work around #23987.

(cherry picked from commit d46e7c7cfd6c286a38298c067f16ac784c2a26f0)

Related: #2087652