### PR TITLE
Revert "shared/install: create relative symlinks for enablement and a…

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -1904,7 +1904,7 @@ static int install_info_symlink_alias(
                 if (!alias_path)
                         return -ENOMEM;
 
-                q = create_symlink(lp, info->name, alias_path, force, changes, n_changes);
+                q = create_symlink(lp, info->path, alias_path, force, changes, n_changes);
                 r = r < 0 ? r : q;
         }
 
@@ -1973,7 +1973,7 @@ static int install_info_symlink_wants(
         }
 
         STRV_FOREACH(s, list) {
-                _cleanup_free_ char *dst = NULL;
+                _cleanup_free_ char *path = NULL, *dst = NULL;
 
                 q = install_name_printf(scope, info, *s, &dst);
                 if (q < 0) {
@@ -2003,15 +2003,11 @@ static int install_info_symlink_wants(
                         continue;
                 }
 
-                _cleanup_free_ char *path = strjoin(config_path, "/", dst, suffix, n);
+                path = strjoin(config_path, "/", dst, suffix, n);
                 if (!path)
                         return -ENOMEM;
 
-                _cleanup_free_ char *target = strjoin("../", info->name);
-                if (!target)
-                        return -ENOMEM;
-
-                q = create_symlink(lp, target, path, true, changes, n_changes);
+                q = create_symlink(lp, info->path, path, true, changes, n_changes);
                 if (r == 0)
                         r = q;
 
@@ -2919,7 +2915,7 @@ int unit_file_set_default(
                 return r;
 
         new_path = strjoina(lp.persistent_config, "/" SPECIAL_DEFAULT_TARGET);
-        return create_symlink(&lp, info->name, new_path, flags & UNIT_FILE_FORCE, changes, n_changes);
+        return create_symlink(&lp, info->path, new_path, flags & UNIT_FILE_FORCE, changes, n_changes);
 }
 
 int unit_file_get_default(

--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -88,7 +88,7 @@ TEST(basic_mask_and_enable) {
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("a.service"), &changes, &n_changes) == 1);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../a.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/a.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/a.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -128,7 +128,7 @@ TEST(basic_mask_and_enable) {
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("d.service"), &changes, &n_changes) >= 0);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../a.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/a.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/a.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -147,7 +147,7 @@ TEST(basic_mask_and_enable) {
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/a.service");
         assert_se(streq(changes[0].path, p));
         assert_se(changes[1].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[1].source, "../a.service"));
+        assert_se(streq(changes[1].source, "/usr/lib/systemd/system/a.service"));
         assert_se(streq(changes[1].path, p));
         unit_file_changes_free(changes, n_changes);
         changes = NULL; n_changes = 0;
@@ -186,7 +186,7 @@ TEST(basic_mask_and_enable) {
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("f.service"), &changes, &n_changes) == 1);
         assert_se(n_changes == 2);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../f.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/f.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/x.target.wants/f.service");
         assert_se(streq(changes[0].path, p));
         assert_se(changes[1].type_or_errno == UNIT_FILE_DESTINATION_NOT_PRESENT);
@@ -280,8 +280,7 @@ TEST(linked_units) {
         q = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/linked.service");
         for (i = 0 ; i < n_changes; i++) {
                 assert_se(changes[i].type_or_errno == UNIT_FILE_SYMLINK);
-                assert_se(STR_IN_SET(changes[i].source,
-                                     "../linked.service", "/opt/linked.service"));
+                assert_se(streq(changes[i].source, "/opt/linked.service"));
 
                 if (p && streq(changes[i].path, p))
                         p = NULL;
@@ -323,8 +322,7 @@ TEST(linked_units) {
         q = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/linked2.service");
         for (i = 0 ; i < n_changes; i++) {
                 assert_se(changes[i].type_or_errno == UNIT_FILE_SYMLINK);
-                assert_se(STR_IN_SET(changes[i].source,
-                                     "../linked2.service", "/opt/linked2.service"));
+                assert_se(streq(changes[i].source, "/opt/linked2.service"));
 
                 if (p && streq(changes[i].path, p))
                         p = NULL;
@@ -342,7 +340,7 @@ TEST(linked_units) {
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
         assert_se(startswith(changes[0].path, root));
         assert_se(endswith(changes[0].path, "linked3.service"));
-        assert_se(streq(changes[0].source, "../linked3.service"));
+        assert_se(streq(changes[0].source, "/opt/linked3.service"));
         unit_file_changes_free(changes, n_changes);
         changes = NULL; n_changes = 0;
 }
@@ -373,7 +371,7 @@ TEST(default) {
         assert_se(unit_file_set_default(LOOKUP_SCOPE_SYSTEM, 0, root, "test-default.target", &changes, &n_changes) >= 0);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "test-default-real.target"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/test-default-real.target"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR "/" SPECIAL_DEFAULT_TARGET);
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -403,7 +401,7 @@ TEST(add_dependency) {
         assert_se(unit_file_add_dependency(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("add-dependency-test-service.service"), "add-dependency-test-target.target", UNIT_WANTS, &changes, &n_changes) >= 0);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../real-add-dependency-test-service.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/real-add-dependency-test-service.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/real-add-dependency-test-target.target.wants/real-add-dependency-test-service.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -444,7 +442,7 @@ TEST(template_enable) {
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("template@.service"), &changes, &n_changes) >= 0);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../template@.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/template@.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/template@def.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -475,14 +473,13 @@ TEST(template_enable) {
 
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("template@foo.service"), &changes, &n_changes) >= 0);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../template@foo.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/template@.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/template@foo.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
         changes = NULL; n_changes = 0;
 
-        assert_se(unit_file_get_state(LOOKUP_SCOPE_SYSTEM, root, "template@.service", &state) >= 0);
-        assert_se(state == UNIT_FILE_INDIRECT);
+        assert_se(unit_file_get_state(LOOKUP_SCOPE_SYSTEM, root, "template@.service", &state) >= 0 && state == UNIT_FILE_INDIRECT);
         assert_se(unit_file_get_state(LOOKUP_SCOPE_SYSTEM, root, "template@def.service", &state) >= 0 && state == UNIT_FILE_DISABLED);
         assert_se(unit_file_get_state(LOOKUP_SCOPE_SYSTEM, root, "template@foo.service", &state) >= 0 && state == UNIT_FILE_ENABLED);
         assert_se(unit_file_get_state(LOOKUP_SCOPE_SYSTEM, root, "template-symlink@foo.service", &state) >= 0 && state == UNIT_FILE_ENABLED);
@@ -509,7 +506,7 @@ TEST(template_enable) {
 
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("template-symlink@quux.service"), &changes, &n_changes) >= 0);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../template@quux.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/template@.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/template@quux.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -555,7 +552,7 @@ TEST(indirect) {
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("indirectc.service"), &changes, &n_changes) >= 0);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../indirectb.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/indirectb.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/indirectb.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -607,7 +604,7 @@ TEST(preset_and_list) {
         assert_se(unit_file_preset(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("preset-yes.service"), UNIT_FILE_PRESET_FULL, &changes, &n_changes) >= 0);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../preset-yes.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/preset-yes.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/preset-yes.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -644,7 +641,7 @@ TEST(preset_and_list) {
         for (i = 0; i < n_changes; i++) {
 
                 if (changes[i].type_or_errno == UNIT_FILE_SYMLINK) {
-                        assert_se(streq(changes[i].source, "../preset-yes.service"));
+                        assert_se(streq(changes[i].source, "/usr/lib/systemd/system/preset-yes.service"));
                         assert_se(streq(changes[i].path, p));
                 } else
                         assert_se(changes[i].type_or_errno == UNIT_FILE_UNLINK);
@@ -760,7 +757,7 @@ TEST(preset_order) {
         assert_se(unit_file_preset(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("prefix-1.service"), UNIT_FILE_PRESET_FULL, &changes, &n_changes) >= 0);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../prefix-1.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/prefix-1.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/prefix-1.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -869,8 +866,8 @@ TEST(with_dropin) {
         assert_se(n_changes == 2);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
         assert_se(changes[1].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../with-dropin-1.service"));
-        assert_se(streq(changes[1].source, "../with-dropin-1.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/with-dropin-1.service"));
+        assert_se(streq(changes[1].source, "/usr/lib/systemd/system/with-dropin-1.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-1.service");
         assert_se(streq(changes[0].path, p));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/graphical.target.wants/with-dropin-1.service");
@@ -883,8 +880,8 @@ TEST(with_dropin) {
         assert_se(n_changes == 2);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
         assert_se(changes[1].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../with-dropin-2.service"));
-        assert_se(streq(changes[1].source, "../with-dropin-2.service"));
+        assert_se(streq(changes[0].source, SYSTEM_CONFIG_UNIT_DIR"/with-dropin-2.service"));
+        assert_se(streq(changes[1].source, SYSTEM_CONFIG_UNIT_DIR"/with-dropin-2.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-2.service");
         assert_se(streq(changes[0].path, p));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/graphical.target.wants/with-dropin-2.service");
@@ -897,8 +894,8 @@ TEST(with_dropin) {
         assert_se(n_changes == 2);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
         assert_se(changes[1].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../with-dropin-3.service"));
-        assert_se(streq(changes[1].source, "../with-dropin-3.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/with-dropin-3.service"));
+        assert_se(streq(changes[1].source, "/usr/lib/systemd/system/with-dropin-3.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-3.service");
         assert_se(streq(changes[0].path, p));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/graphical.target.wants/with-dropin-3.service");
@@ -911,8 +908,8 @@ TEST(with_dropin) {
         assert_se(n_changes == 2);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
         assert_se(changes[1].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../with-dropin-4a.service"));
-        assert_se(streq(changes[1].source, "../with-dropin-4b.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/with-dropin-4a.service"));
+        assert_se(streq(changes[1].source, "/usr/lib/systemd/system/with-dropin-4b.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-4a.service");
         assert_se(streq(changes[0].path, p));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-4b.service");
@@ -978,8 +975,8 @@ TEST(with_dropin_template) {
         assert_se(n_changes == 2);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
         assert_se(changes[1].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../with-dropin-1@instance-1.service"));
-        assert_se(streq(changes[1].source, "../with-dropin-1@instance-1.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/with-dropin-1@.service"));
+        assert_se(streq(changes[1].source, "/usr/lib/systemd/system/with-dropin-1@.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-1@instance-1.service");
         assert_se(streq(changes[0].path, p));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/graphical.target.wants/with-dropin-1@instance-1.service");
@@ -991,8 +988,8 @@ TEST(with_dropin_template) {
         assert_se(n_changes == 2);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
         assert_se(changes[1].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../with-dropin-2@instance-1.service"));
-        assert_se(streq(changes[1].source, "../with-dropin-2@instance-1.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/with-dropin-2@.service"));
+        assert_se(streq(changes[1].source, "/usr/lib/systemd/system/with-dropin-2@.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-2@instance-1.service");
         assert_se(streq(changes[0].path, p));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/graphical.target.wants/with-dropin-2@instance-1.service");
@@ -1003,7 +1000,7 @@ TEST(with_dropin_template) {
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("with-dropin-2@instance-2.service"), &changes, &n_changes) == 1);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../with-dropin-2@instance-2.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/with-dropin-2@.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-2@instance-2.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);
@@ -1012,7 +1009,7 @@ TEST(with_dropin_template) {
         assert_se(unit_file_enable(LOOKUP_SCOPE_SYSTEM, 0, root, STRV_MAKE("with-dropin-3@.service"), &changes, &n_changes) == 1);
         assert_se(n_changes == 1);
         assert_se(changes[0].type_or_errno == UNIT_FILE_SYMLINK);
-        assert_se(streq(changes[0].source, "../with-dropin-3@.service"));
+        assert_se(streq(changes[0].source, "/usr/lib/systemd/system/with-dropin-3@.service"));
         p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/with-dropin-3@instance-2.service");
         assert_se(streq(changes[0].path, p));
         unit_file_changes_free(changes, n_changes);

--- a/test/test-systemctl-enable.sh
+++ b/test/test-systemctl-enable.sh
@@ -90,27 +90,27 @@ EOF
 ( ! "$systemctl" --root="$root" enable test1 )
 test -h "$root/etc/systemd/system/default.target.wants/test1.service"
 test -h "$root/etc/systemd/system/special.target.requires/test1.service"
-test -e "$root/etc/systemd/system/test1-goodalias.service"
+test ! -e "$root/etc/systemd/system/test1-goodalias.service"
 test -h "$root/etc/systemd/system/test1-goodalias.service"
-test ! -h "$root/etc/systemd/system/test1@badalias.service"
-test ! -h "$root/etc/systemd/system/test1-badalias.target"
-test ! -h "$root/etc/systemd/system/test1-badalias.socket"
-test -e "$root/etc/systemd/system/test1-goodalias2.service"
+test ! -e "$root/etc/systemd/system/test1@badalias.service"
+test ! -e "$root/etc/systemd/system/test1-badalias.target"
+test ! -e "$root/etc/systemd/system/test1-badalias.socket"
 test -h "$root/etc/systemd/system/test1-goodalias2.service"
 
 : '-------aliases in reeanble----------------------------------'
 ( ! "$systemctl" --root="$root" reenable test1 )
-islink "$root/etc/systemd/system/default.target.wants/test1.service" "../test1.service"
-islink "$root/etc/systemd/system/test1-goodalias.service" "test1.service"
+test -h "$root/etc/systemd/system/default.target.wants/test1.service"
+test ! -e "$root/etc/systemd/system/test1-goodalias.service"
+test -h "$root/etc/systemd/system/test1-goodalias.service"
 
-test ! -h "$root/etc/systemd/system/test1@badalias.service"
-test ! -h "$root/etc/systemd/system/test1-badalias.target"
-test ! -h "$root/etc/systemd/system/test1-badalias.socket"
+test ! -e "$root/etc/systemd/system/test1@badalias.service"
+test ! -e "$root/etc/systemd/system/test1-badalias.target"
+test ! -e "$root/etc/systemd/system/test1-badalias.socket"
 
 "$systemctl" --root="$root" disable test1
-test ! -h "$root/etc/systemd/system/default.target.wants/test1.service"
-test ! -h "$root/etc/systemd/system/special.target.requires/test1.service"
-test ! -h "$root/etc/systemd/system/test1-goodalias.service"
+test ! -e "$root/etc/systemd/system/default.target.wants/test1.service"
+test ! -e "$root/etc/systemd/system/special.target.requires/test1.service"
+test ! -e "$root/etc/systemd/system/test1-goodalias.service"
 
 : '-------aliases when link already exists---------------------'
 cat >"$root/etc/systemd/system/test1a.service" <<EOF
@@ -201,17 +201,17 @@ test ! -e "$root/etc/systemd/system/link1.path"
 : '-------link and enable--------------------------------------'
 "$systemctl" --root="$root" enable '/link1.path'
 islink "$root/etc/systemd/system/link1.path" "/link1.path"
-islink "$root/etc/systemd/system/paths.target.wants/link1.path" "../link1.path"
+islink "$root/etc/systemd/system/paths.target.wants/link1.path" "/link1.path"
 
 : '-------enable already linked same path----------------------'
 "$systemctl" --root="$root" enable '/link1.path'
 islink "$root/etc/systemd/system/link1.path" "/link1.path"
-islink "$root/etc/systemd/system/paths.target.wants/link1.path" "../link1.path"
+islink "$root/etc/systemd/system/paths.target.wants/link1.path" "/link1.path"
 
 : '-------enable already linked different path-----------------'
 ( ! "$systemctl" --root="$root" enable '/subdir/link1.path' )
 islink "$root/etc/systemd/system/link1.path" "/link1.path"
-islink "$root/etc/systemd/system/paths.target.wants/link1.path" "../link1.path"
+islink "$root/etc/systemd/system/paths.target.wants/link1.path" "/link1.path"
 
 : '-------enable bad suffix------------------------------------'
 cp "$root/link1.path" "$root/subdir/link1.suffix"
@@ -240,11 +240,11 @@ test ! -h "$root/etc/systemd/system/paths.target.wants/link1.path"
 
 "$systemctl" --root="$root" enable 'link1.path'
 islink "$root/etc/systemd/system/link1.path" "/link1.path"
-islink "$root/etc/systemd/system/paths.target.wants/link1.path" "../link1.path"
+islink "$root/etc/systemd/system/paths.target.wants/link1.path" "/link1.path"
 
 "$systemctl" --root="$root" reenable 'link1.path'
 islink "$root/etc/systemd/system/link1.path" "/link1.path"
-islink "$root/etc/systemd/system/paths.target.wants/link1.path" "../link1.path"
+islink "$root/etc/systemd/system/paths.target.wants/link1.path" "/link1.path"
 
 : '-------manual link------------------------------------------'
 cat >"$root/link3.suffix" <<EOF
@@ -257,7 +257,7 @@ ln -s "/link3.suffix" "$root/etc/systemd/system/link3.service"
 
 SYSTEMD_LOG_LEVEL=debug SYSTEMD_LOG_LOCATION=1 "$systemctl" --root="$root" enable 'link3.service'
 islink "$root/etc/systemd/system/link3.service" "/link3.suffix"
-islink "$root/etc/systemd/system/services.target.wants/link3.service" "../link3.service"
+islink "$root/etc/systemd/system/services.target.wants/link3.service" "/link3.suffix"
 
 SYSTEMD_LOG_LEVEL=debug SYSTEMD_LOG_LOCATION=1 "$systemctl" --root="$root" disable 'link3.service'
 test ! -h "$root/etc/systemd/system/link3.service"
@@ -293,7 +293,7 @@ test ! -h "$root/etc/systemd/system/services.target.wants/link5-also.service"
 
 "$systemctl" --root="$root" enable 'link5-also.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/link5.service"
-islink "$root/etc/systemd/system/services.target.wants/link5-also.service" "../link5-also.service"
+islink "$root/etc/systemd/system/services.target.wants/link5-also.service" "/etc/systemd/system/link5-also.service"
 
 : '-------template enablement----------------------------------'
 cat >"$root/etc/systemd/system/templ1@.service" <<EOF
@@ -307,17 +307,17 @@ test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
 
 "$systemctl" --root="$root" enable 'templ1@one.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@one.service" "../templ1@one.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@one.service" "/etc/systemd/system/templ1@.service"
 
 "$systemctl" --root="$root" enable 'templ1@two.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@one.service" "../templ1@one.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@two.service" "../templ1@two.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@one.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@two.service" "/etc/systemd/system/templ1@.service"
 
 "$systemctl" --root="$root" disable 'templ1@one.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@one.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@two.service" "../templ1@two.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@two.service" "/etc/systemd/system/templ1@.service"
 
 "$systemctl" --root="$root" disable 'templ1@two.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
@@ -335,33 +335,33 @@ EOF
 
 "$systemctl" --root="$root" enable 'templ1@.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@333.service" "../templ1@.service"
-islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@333.service" "../templ1@.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@333.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@333.service" "/etc/systemd/system/templ1@.service"
 
 "$systemctl" --root="$root" enable 'templ1@one.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@333.service" "../templ1@.service"
-islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@333.service" "../templ1@.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@one.service" "../templ1@one.service"
-islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@one.service" "../templ1@one.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@333.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@333.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@one.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@one.service" "/etc/systemd/system/templ1@.service"
 
 "$systemctl" --root="$root" enable 'templ1@two.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@333.service" "../templ1@.service"
-islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@333.service" "../templ1@.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@one.service" "../templ1@one.service"
-islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@one.service" "../templ1@one.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@two.service" "../templ1@two.service"
-islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@two.service" "../templ1@two.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@333.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@333.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@one.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@one.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@two.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@two.service" "/etc/systemd/system/templ1@.service"
 
 "$systemctl" --root="$root" disable 'templ1@one.service'
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@333.service" "../templ1@.service"
-islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@333.service" "../templ1@.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@333.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@333.service" "/etc/systemd/system/templ1@.service"
 test ! -h "$root/etc/systemd/system/services.target.wants/templ1@one.service"
 test ! -h "$root/etc/systemd/system/other@templ1.target.requires/templ1@one.service"
-islink "$root/etc/systemd/system/services.target.wants/templ1@two.service" "../templ1@two.service"
-islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@two.service" "../templ1@two.service"
+islink "$root/etc/systemd/system/services.target.wants/templ1@two.service" "/etc/systemd/system/templ1@.service"
+islink "$root/etc/systemd/system/other@templ1.target.requires/templ1@two.service" "/etc/systemd/system/templ1@.service"
 
 # disable remaining links here
 "$systemctl" --root="$root" disable 'templ1@.service'
@@ -400,18 +400,18 @@ RequiredBy=another-template@.target
 EOF
 
 "$systemctl" --root="$root" enable 'templ2@.service'
-islink "$root/etc/systemd/system/another-template@.target.requires/templ2@.service" "../templ2@.service"
+islink "$root/etc/systemd/system/another-template@.target.requires/templ2@.service" "/etc/systemd/system/templ2@.service"
 
 "$systemctl" --root="$root" enable 'templ2@two.service'
-islink "$root/etc/systemd/system/another-template@.target.requires/templ2@.service" "../templ2@.service"
-islink "$root/etc/systemd/system/another-template@.target.requires/templ2@two.service" "../templ2@two.service"
+islink "$root/etc/systemd/system/another-template@.target.requires/templ2@.service" "/etc/systemd/system/templ2@.service"
+islink "$root/etc/systemd/system/another-template@.target.requires/templ2@two.service" "/etc/systemd/system/templ2@.service"
 
 "$systemctl" --root="$root" disable 'templ2@other.service'
-islink "$root/etc/systemd/system/another-template@.target.requires/templ2@.service" "../templ2@.service"
-islink "$root/etc/systemd/system/another-template@.target.requires/templ2@two.service" "../templ2@two.service"
+islink "$root/etc/systemd/system/another-template@.target.requires/templ2@.service" "/etc/systemd/system/templ2@.service"
+islink "$root/etc/systemd/system/another-template@.target.requires/templ2@two.service" "/etc/systemd/system/templ2@.service"
 
 "$systemctl" --root="$root" disable 'templ2@two.service'
-islink "$root/etc/systemd/system/another-template@.target.requires/templ2@.service" "../templ2@.service"
+islink "$root/etc/systemd/system/another-template@.target.requires/templ2@.service" "/etc/systemd/system/templ2@.service"
 test ! -h "$root/etc/systemd/system/another-template@.target.requires/templ2@two.service"
 
 "$systemctl" --root="$root" disable 'templ2@.service'
@@ -433,8 +433,8 @@ EOF
 test ! -h "$root/etc/systemd/system/link4.service"  # this is our file
 test ! -h "$root/etc/systemd/system/link4@.service"
 test ! -h "$root/etc/systemd/system/link4@inst.service"
-islink "$root/etc/systemd/system/link4alias.service" "link4.service"
-islink "$root/etc/systemd/system/link4alias2.service" "link4.service"
+islink "$root/etc/systemd/system/link4alias.service" "/etc/systemd/system/link4.service"
+islink "$root/etc/systemd/system/link4alias2.service" "/etc/systemd/system/link4.service"
 
 "$systemctl" --root="$root" disable 'link4.service'
 test ! -h "$root/etc/systemd/system/link4.service"
@@ -453,8 +453,8 @@ EOF
 # Apparently this works. I'm not sure what to think.
 "$systemctl" --root="$root" enable '/etc/systemd/system/link4.service'
 test ! -h "$root/etc/systemd/system/link4.service"  # this is our file
-islink "$root/etc/systemd/system/link4alias.service" "link4.service"
-islink "$root/etc/systemd/system/link4alias2.service" "link4.service"
+islink "$root/etc/systemd/system/link4alias.service" "/etc/systemd/system/link4.service"
+islink "$root/etc/systemd/system/link4alias2.service" "/etc/systemd/system/link4.service"
 
 "$systemctl" --root="$root" disable '/etc/systemd/system/link4.service'
 test ! -h "$root/etc/systemd/system/link4.service"
@@ -472,8 +472,8 @@ EOF
 
 "$systemctl" --root="$root" enable 'link5.service'
 test ! -h "$root/etc/systemd/system/link5.service"  # this is our file
-islink "$root/etc/systemd/system/link5alias.service" "link5.service"
-islink "$root/etc/systemd/system/link5alias2.service" "link5.service"
+islink "$root/etc/systemd/system/link5alias.service" "/etc/systemd/system/link5.service"
+islink "$root/etc/systemd/system/link5alias2.service" "/etc/systemd/system/link5.service"
 
 "$systemctl" --root="$root" disable 'link5.service'
 test ! -h "$root/etc/systemd/system/link5alias.service"
@@ -495,6 +495,10 @@ islink "$root/etc/systemd/system/link5copy.service" '/link5copy.service'
 test ! -h "$root/etc/systemd/system/link5alias.service"
 test ! -h "$root/etc/systemd/system/link5alias2.service"
 
+# FIXME: we must create link5alias2 and link5alias as relative links to link5.service
+# When they are independent links to /link5.service, systemd doesn't know that
+# they are aliases, because we do not follow symlinks outside of the search paths.
+
 "$systemctl" --root="$root" disable 'link5copy.service'
 test ! -h "$root/etc/systemd/system/link5copy.service"
 test ! -h "$root/etc/systemd/system/link5alias.service"
@@ -502,8 +506,8 @@ test ! -h "$root/etc/systemd/system/link5alias2.service"
 
 "$systemctl" --root="$root" enable '/link5copy.service'
 islink "$root/etc/systemd/system/link5copy.service" '/link5copy.service'
-islink "$root/etc/systemd/system/link5alias.service" 'link5copy.service'
-islink "$root/etc/systemd/system/link5alias2.service" 'link5copy.service'
+islink "$root/etc/systemd/system/link5alias.service" '/link5copy.service'
+islink "$root/etc/systemd/system/link5alias2.service" '/link5copy.service'
 
 "$systemctl" --root="$root" disable 'link5copy.service'
 test ! -h "$root/etc/systemd/system/link5copy.service"
@@ -522,10 +526,10 @@ EOF
 
 "$systemctl" --root="$root" enable 'link5@.path'
 test ! -h "$root/etc/systemd/system/link5@.path"  # this is our file
-islink "$root/etc/systemd/system/target5@.target.wants/link5@.path" "../link5@.path"
-islink "$root/etc/systemd/system/target5@.target.requires/link5@.path" "../link5@.path"
-islink "$root/etc/systemd/system/target5@inst.target.wants/link5@.path" "../link5@.path"
-islink "$root/etc/systemd/system/target5@inst.target.requires/link5@.path" "../link5@.path"
+islink "$root/etc/systemd/system/target5@.target.wants/link5@.path" "/etc/systemd/system/link5@.path"
+islink "$root/etc/systemd/system/target5@.target.requires/link5@.path" "/etc/systemd/system/link5@.path"
+islink "$root/etc/systemd/system/target5@inst.target.wants/link5@.path" "/etc/systemd/system/link5@.path"
+islink "$root/etc/systemd/system/target5@inst.target.requires/link5@.path" "/etc/systemd/system/link5@.path"
 
 "$systemctl" --root="$root" disable 'link5@.path'
 test ! -h "$root/etc/systemd/system/link5@.path"  # this is our file
@@ -564,7 +568,7 @@ check_alias() {
 Alias=target@$1:%$1.socket
 EOF
     SYSTEMD_LOG_LEVEL=debug "$systemctl" --root="$root" enable 'some-some-link6@.socket' || return 1
-    islink "$root/etc/systemd/system/target@$1:$2.socket" "some-some-link6@.socket" || return 2
+    islink "$root/etc/systemd/system/target@$1:$2.socket" "/etc/systemd/system/some-some-link6@.socket" || return 2
 }
 
 # TODO: our architecture names are different than what uname -m returns.
@@ -669,10 +673,10 @@ RequiredBy=another-target2@.target
 EOF
 
 "$systemctl" --root="$root" enable 'some-some-link7.socket'
-islink "$root/etc/systemd/system/target@some-some-link7.target.wants/some-some-link7.socket" "../some-some-link7.socket"
-islink "$root/etc/systemd/system/another-target@.target.wants/some-some-link7.socket" "../some-some-link7.socket"
-islink "$root/etc/systemd/system/target2@some-some-link7.target.requires/some-some-link7.socket" "../some-some-link7.socket"
-islink "$root/etc/systemd/system/another-target2@.target.requires/some-some-link7.socket" "../some-some-link7.socket"
+islink "$root/etc/systemd/system/target@some-some-link7.target.wants/some-some-link7.socket" "/etc/systemd/system/some-some-link7.socket"
+islink "$root/etc/systemd/system/another-target@.target.wants/some-some-link7.socket" "/etc/systemd/system/some-some-link7.socket"
+islink "$root/etc/systemd/system/target2@some-some-link7.target.requires/some-some-link7.socket" "/etc/systemd/system/some-some-link7.socket"
+islink "$root/etc/systemd/system/another-target2@.target.requires/some-some-link7.socket" "/etc/systemd/system/some-some-link7.socket"
 
 "$systemctl" --root="$root" disable 'some-some-link7.socket'
 test ! -h "$root/etc/systemd/system/target@some-some-link7.target.wants/some-some-link7.socket"


### PR DESCRIPTION
…liasing"

This reverts commit d6c9411072901556176ac130f2ce71a33107aa93.

I still think this is something that needs to be done, but we're hitting some
unexplained failures, e.g. https://github.com/systemd/systemd/issues/22920.
So let's revert this for now, so -rc2 can be released, with a plan to return
to this after a release.

Closes #22920.

(cherry picked from commit 9aa3d6b41eadff6634bb3cf800064724171a7aad)

Resolves: #2118668