### PR TITLE
shared/install: fix crash when reenable is called without --root

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -2827,7 +2827,7 @@ static int normalize_linked_files(
                         return r;
 
                 const char *p = NULL;
-                if (i && i->path)
+                if (i && i->path && i->root)
                         /* Use startswith here, because we know that paths are normalized, and
                          * path_startswith() would give us a relative path, but we need an absolute path
                          * relative to i->root.


### PR DESCRIPTION
(cherry picked from commit 6e961aeb262521742a4cd92e4620de193f159f7c)

Resolves: #2120222