### PR TITLE
time-util: fix buffer-over-run

### DIFF
--- a/src/basic/time-util.c
+++ b/src/basic/time-util.c
@@ -598,7 +598,7 @@ char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy) {
                         t = b;
                 }
 
-                n = MIN((size_t) k, l);
+                n = MIN((size_t) k, l-1);
 
                 l -= n;
                 p += n;

--- a/src/test/test-time-util.c
+++ b/src/test/test-time-util.c
@@ -238,6 +238,11 @@ TEST(format_timespan) {
         test_format_timespan_accuracy(1);
         test_format_timespan_accuracy(USEC_PER_MSEC);
         test_format_timespan_accuracy(USEC_PER_SEC);
+
+        /* See issue #23928. */
+        _cleanup_free_ char *buf;
+        assert_se(buf = new(char, 5));
+        assert_se(buf == format_timespan(buf, 5, 100005, 1000));
 }
 
 TEST(verify_timezone) {


### PR DESCRIPTION
Fixes #23928.

(cherry picked from commit 9102c625a673a3246d7e73d8737f3494446bad4e)

Resolves: [#2139388](https://bugzilla.redhat.com/show_bug.cgi?id=2139388)