### PR TITLE
(#2141979) test: check if we can use SHA1 MD for signing before using it

### DIFF
--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -1572,7 +1572,7 @@ static EFI_STATUS efivar_get_timeout(const char16_t *var, uint32_t *ret_value) {
 
 static void config_load_defaults(Config *config, EFI_FILE *root_dir) {
         _cleanup_free_ char *content = NULL;
-        UINTN value;
+        UINTN value = 0;  /* avoid false maybe-uninitialized warning */
         EFI_STATUS err;
 
         assert(root_dir);
@@ -2258,7 +2258,7 @@ static void config_load_xbootldr(
                 EFI_HANDLE *device) {
 
         _cleanup_(file_closep) EFI_FILE *root_dir = NULL;
-        EFI_HANDLE new_device;
+        EFI_HANDLE new_device = NULL;  /* avoid false maybe-uninitialized warning */
         EFI_STATUS err;
 
         assert(config);

--- a/src/boot/efi/cpio.c
+++ b/src/boot/efi/cpio.c
@@ -485,7 +485,7 @@ EFI_STATUS pack_cpio(
 
         for (UINTN i = 0; i < n_items; i++) {
                 _cleanup_free_ char *content = NULL;
-                UINTN contentsize;
+                UINTN contentsize = 0;  /* avoid false maybe-uninitialized warning */
 
                 err = file_read(extra_dir, items[i], 0, 0, &content, &contentsize);
                 if (err != EFI_SUCCESS) {

--- a/src/boot/efi/secure-boot.c
+++ b/src/boot/efi/secure-boot.c
@@ -6,7 +6,7 @@
 #include "util.h"
 
 bool secure_boot_enabled(void) {
-        bool secure;
+        bool secure = false;  /* avoid false maybe-uninitialized warning */
         EFI_STATUS err;
 
         err = efivar_get_boolean_u8(EFI_GLOBAL_GUID, L"SecureBoot", &secure);

--- a/src/boot/efi/util.c
+++ b/src/boot/efi/util.c
@@ -91,7 +91,7 @@ EFI_STATUS efivar_set_uint64_le(const EFI_GUID *vendor, const char16_t *name, ui
         return efivar_set_raw(vendor, name, buf, sizeof(buf), flags);
 }
 
-EFI_STATUS efivar_get(const EFI_GUID *vendor, const char16_t *name, char16_t **value) {
+EFI_STATUS efivar_get(const EFI_GUID *vendor, const char16_t *name, char16_t **ret) {
         _cleanup_free_ char16_t *buf = NULL;
         EFI_STATUS err;
         char16_t *val;
@@ -108,12 +108,12 @@ EFI_STATUS efivar_get(const EFI_GUID *vendor, const char16_t *name, char16_t **v
         if ((size % sizeof(char16_t)) != 0)
                 return EFI_INVALID_PARAMETER;
 
-        if (!value)
+        if (!ret)
                 return EFI_SUCCESS;
 
         /* Return buffer directly if it happens to be NUL terminated already */
         if (size >= sizeof(char16_t) && buf[size / sizeof(char16_t) - 1] == 0) {
-                *value = TAKE_PTR(buf);
+                *ret = TAKE_PTR(buf);
                 return EFI_SUCCESS;
         }
 
@@ -123,18 +123,17 @@ EFI_STATUS efivar_get(const EFI_GUID *vendor, const char16_t *name, char16_t **v
         memcpy(val, buf, size);
         val[size / sizeof(char16_t) - 1] = 0; /* NUL terminate */
 
-        *value = val;
+        *ret = val;
         return EFI_SUCCESS;
 }
 
-EFI_STATUS efivar_get_uint_string(const EFI_GUID *vendor, const char16_t *name, UINTN *i) {
+EFI_STATUS efivar_get_uint_string(const EFI_GUID *vendor, const char16_t *name, UINTN *ret) {
         _cleanup_free_ char16_t *val = NULL;
         EFI_STATUS err;
         uint64_t u;
 
         assert(vendor);
         assert(name);
-        assert(i);
 
         err = efivar_get(vendor, name, &val);
         if (err != EFI_SUCCESS)
@@ -143,7 +142,8 @@ EFI_STATUS efivar_get_uint_string(const EFI_GUID *vendor, const char16_t *name, 
         if (!parse_number16(val, &u, NULL) || u > UINTN_MAX)
                 return EFI_INVALID_PARAMETER;
 
-        *i = u;
+        if (ret)
+                *ret = u;
         return EFI_SUCCESS;
 }
 
@@ -156,15 +156,17 @@ EFI_STATUS efivar_get_uint32_le(const EFI_GUID *vendor, const char16_t *name, ui
         assert(name);
 
         err = efivar_get_raw(vendor, name, &buf, &size);
-        if (err == EFI_SUCCESS && ret) {
-                if (size != sizeof(uint32_t))
-                        return EFI_BUFFER_TOO_SMALL;
+        if (err != EFI_SUCCESS)
+                return err;
 
+        if (size != sizeof(uint32_t))
+                return EFI_BUFFER_TOO_SMALL;
+
+        if (ret)
                 *ret = (uint32_t) buf[0] << 0U | (uint32_t) buf[1] << 8U | (uint32_t) buf[2] << 16U |
                         (uint32_t) buf[3] << 24U;
-        }
 
-        return err;
+        return EFI_SUCCESS;
 }
 
 EFI_STATUS efivar_get_uint64_le(const EFI_GUID *vendor, const char16_t *name, uint64_t *ret) {
@@ -176,19 +178,21 @@ EFI_STATUS efivar_get_uint64_le(const EFI_GUID *vendor, const char16_t *name, ui
         assert(name);
 
         err = efivar_get_raw(vendor, name, &buf, &size);
-        if (err == EFI_SUCCESS && ret) {
-                if (size != sizeof(uint64_t))
-                        return EFI_BUFFER_TOO_SMALL;
+        if (err != EFI_SUCCESS)
+                return err;
 
+        if (size != sizeof(uint64_t))
+                return EFI_BUFFER_TOO_SMALL;
+
+        if (ret)
                 *ret = (uint64_t) buf[0] << 0U | (uint64_t) buf[1] << 8U | (uint64_t) buf[2] << 16U |
                         (uint64_t) buf[3] << 24U | (uint64_t) buf[4] << 32U | (uint64_t) buf[5] << 40U |
                         (uint64_t) buf[6] << 48U | (uint64_t) buf[7] << 56U;
-        }
 
-        return err;
+        return EFI_SUCCESS;
 }
 
-EFI_STATUS efivar_get_raw(const EFI_GUID *vendor, const char16_t *name, char **buffer, UINTN *size) {
+EFI_STATUS efivar_get_raw(const EFI_GUID *vendor, const char16_t *name, char **ret, UINTN *ret_size) {
         _cleanup_free_ char *buf = NULL;
         UINTN l;
         EFI_STATUS err;
@@ -200,16 +204,15 @@ EFI_STATUS efivar_get_raw(const EFI_GUID *vendor, const char16_t *name, char **b
         buf = xmalloc(l);
 
         err = RT->GetVariable((char16_t *) name, (EFI_GUID *) vendor, NULL, &l, buf);
-        if (err == EFI_SUCCESS) {
+        if (err != EFI_SUCCESS)
+                return err;
 
-                if (buffer)
-                        *buffer = TAKE_PTR(buf);
+        if (ret)
+                *ret = TAKE_PTR(buf);
+        if (ret_size)
+                *ret_size = l;
 
-                if (size)
-                        *size = l;
-        }
-
-        return err;
+        return EFI_SUCCESS;
 }
 
 EFI_STATUS efivar_get_boolean_u8(const EFI_GUID *vendor, const char16_t *name, bool *ret) {
@@ -219,13 +222,15 @@ EFI_STATUS efivar_get_boolean_u8(const EFI_GUID *vendor, const char16_t *name, b
 
         assert(vendor);
         assert(name);
-        assert(ret);
 
         err = efivar_get_raw(vendor, name, &b, &size);
-        if (err == EFI_SUCCESS)
+        if (err != EFI_SUCCESS)
+                return err;
+
+        if (ret)
                 *ret = *b > 0;
 
-        return err;
+        return EFI_SUCCESS;
 }
 
 void efivar_set_time_usec(const EFI_GUID *vendor, const char16_t *name, uint64_t usec) {

--- a/src/boot/efi/util.h
+++ b/src/boot/efi/util.h
@@ -105,9 +105,9 @@ EFI_STATUS efivar_set_uint32_le(const EFI_GUID *vendor, const char16_t *NAME, ui
 EFI_STATUS efivar_set_uint64_le(const EFI_GUID *vendor, const char16_t *name, uint64_t value, uint32_t flags);
 void efivar_set_time_usec(const EFI_GUID *vendor, const char16_t *name, uint64_t usec);
 
-EFI_STATUS efivar_get(const EFI_GUID *vendor, const char16_t *name, char16_t **value);
-EFI_STATUS efivar_get_raw(const EFI_GUID *vendor, const char16_t *name, char **buffer, UINTN *size);
-EFI_STATUS efivar_get_uint_string(const EFI_GUID *vendor, const char16_t *name, UINTN *i);
+EFI_STATUS efivar_get(const EFI_GUID *vendor, const char16_t *name, char16_t **ret);
+EFI_STATUS efivar_get_raw(const EFI_GUID *vendor, const char16_t *name, char **ret, UINTN *ret_size);
+EFI_STATUS efivar_get_uint_string(const EFI_GUID *vendor, const char16_t *name, UINTN *ret);
 EFI_STATUS efivar_get_uint32_le(const EFI_GUID *vendor, const char16_t *name, uint32_t *ret);
 EFI_STATUS efivar_get_uint64_le(const EFI_GUID *vendor, const char16_t *name, uint64_t *ret);
 EFI_STATUS efivar_get_boolean_u8(const EFI_GUID *vendor, const char16_t *name, bool *ret);


### PR DESCRIPTION
Some distributions have started phasing out SHA1, which breaks the systemd-measure test case in its current form. Let's make sure we can use SHA1 for signing beforehand to mitigate this.

Spotted on RHEL 9, where SHA1 signatures are disallowed by [0]:
```
openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "/tmp/pcrsign-private.pem"
...
openssl rsa -pubout -in "/tmp/pcrsign-private.pem" -out "/tmp/pcrsign-public.pem"
writing RSA key
/usr/lib/systemd/systemd-measure sign --current --bank=sha1 --private-key="/tmp/pcrsign-private.pem" --public-key="/tmp/pcrsign-public.pem"
Failed to initialize signature context.
```

[0] https://gitlab.com/redhat/centos-stream/rpms/openssl/-/blob/c9s/0049-Selectively-disallow-SHA1-signatures.patch

(cherry picked from commit d19e5540f20c78caa949ff33050b4a530cae1982)

Related: #2141979