### PR TITLE
(#2151993) swap: tell swapon to reinitialize swap if needed

### DIFF
--- a/src/core/swap.c
+++ b/src/core/swap.c
@@ -827,7 +827,7 @@ static void swap_enter_activating(Swap *s) {
                 }
         }
 
-        r = exec_command_set(s->control_command, "/sbin/swapon", NULL);
+        r = exec_command_set(s->control_command, "/sbin/swapon", "--fixpgsz", NULL);
         if (r < 0)
                 goto fail;
 


### PR DESCRIPTION
If the page size of a swap space doesn't match the page size of the currently running kernel, swapon will fail. Let's instruct it to reinitialize the swap space instead.

(cherry picked from commit cc137d53e36da5e57b060be5e621864f572b2cac)

Resolves: [#2151993](https://bugzilla.redhat.com/show_bug.cgi?id=2151993)