### PR TITLE
(#2159448) udev: make get_virtfn_info() provide physical PCI device

### DIFF
--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -144,7 +144,7 @@ static int get_virtfn_info(sd_device *pcidev, sd_device **ret_physfn_pcidev, cha
                         if (!suffix)
                                 return -ENOMEM;
 
-                        *ret_physfn_pcidev = sd_device_ref(child);
+                        *ret_physfn_pcidev = sd_device_ref(physfn_pcidev);
                         *ret_suffix = suffix;
                         return 0;
                 }


### PR DESCRIPTION
Fixes a bug introduced by 78463c6c4fdcb703bc0dc694c3ea77df3c5624e0.

Fixes #25545.

(cherry picked from commit cf74e2e16fb06b7de9e3875c6462290998fb06bd)

Resolves: #2159448