### PR TITLE
(#2138081) Fix PID1 crash at `systemctl enable`

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -1982,6 +1982,8 @@ static int install_info_symlink_wants(
                         install_changes_add(changes, n_changes, q, *s, NULL);
                         if (r >= 0)
                                 r = q;
+
+                        continue;
                 }
 
                 if (!unit_name_is_valid(dst, valid_dst_type)) {

--- a/test/units/testsuite-26.sh
+++ b/test/units/testsuite-26.sh
@@ -400,5 +400,17 @@ EOF
     systemctl stop issue-24990
 fi
 
+# %J in WantedBy= causes ABRT (#26467)
+cat >/run/systemd/system/test-WantedBy.service <<EOF
+[Service]
+ExecStart=true
+
+[Install]
+WantedBy=user-%i@%J.service
+EOF
+systemctl daemon-reload
+systemctl enable --now test-WantedBy.service || :
+systemctl daemon-reload
+
 touch /testok
 rm /failed


### PR DESCRIPTION
Related: [#2138081](https://bugzilla.redhat.com/show_bug.cgi?id=2138081)