### PR TITLE
(#2178222) Revert workaround for disabled idmapped mounts

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -3806,7 +3806,7 @@ static int outer_child(
             arg_uid_shift != 0) {
 
                 r = remount_idmap(directory, arg_uid_shift, arg_uid_range, UID_INVALID, REMOUNT_IDMAPPING_HOST_ROOT);
-                if (IN_SET(r, -EINVAL, -EPERM) || ERRNO_IS_NOT_SUPPORTED(r)) {
+                if (r == -EINVAL || ERRNO_IS_NOT_SUPPORTED(r)) {
                         /* This might fail because the kernel or file system doesn't support idmapping. We
                          * can't really distinguish this nicely, nor do we have any guarantees about the
                          * error codes we see, could be EOPNOTSUPP or EINVAL. */

--- a/test/units/testsuite-13.sh
+++ b/test/units/testsuite-13.sh
@@ -74,7 +74,7 @@ function check_rootidmap {
             --register=no -D "$_root" \
             --bind=/tmp/rootidmapdir:/mnt:rootidmap \
             /bin/sh -c "$_command" |& tee nspawn.out; then
-        if grep -Eq "Failed to map ids for bind mount.*: (Function not implemented|Operation not permitted)" nspawn.out; then
+        if grep -q "Failed to map ids for bind mount.*: Function not implemented" nspawn.out; then
             echo "idmapped mounts are not supported, skipping the test..."
             return 0
         fi


### PR DESCRIPTION
Resolves: [#2178222](https://bugzilla.redhat.com/show_bug.cgi?id=2178222)

<!-- advanced-commit-linter = {"comment-id":"1680557182"} -->