### PR TITLE
(#2182632) Count size of all journal files when vacuuming

### DIFF
--- a/src/basic/alloc-util.h
+++ b/src/basic/alloc-util.h
@@ -14,6 +14,7 @@
 
 typedef void (*free_func_t)(void *p);
 typedef void* (*mfree_func_t)(void *p);
+typedef void (*free_array_func_t)(void *p, size_t n);
 
 /* If for some reason more than 4M are allocated on the stack, let's abort immediately. It's better than
  * proceeding and smashing the stack limits. Note that by default RLIMIT_STACK is 8M on Linux. */

--- a/src/basic/macro.h
+++ b/src/basic/macro.h
@@ -329,6 +329,13 @@ static inline int __coverity_check_and_return__(int condition) {
 #endif
 #endif
 
+#define _FOREACH_ARRAY(i, array, num, m, s)                             \
+        for (typeof(num) m = (num); m > 0; m = 0)                       \
+                for (typeof(array[0]) *s = (array), *i = s; s && i < s + m; i++)
+
+#define FOREACH_ARRAY(i, array, num)                                    \
+        _FOREACH_ARRAY(i, array, num, UNIQ_T(m, UNIQ), UNIQ_T(s, UNIQ))
+
 #define DEFINE_TRIVIAL_DESTRUCTOR(name, type, func)             \
         static inline void name(type *p) {                      \
                 func(p);                                        \

--- a/src/basic/memory-util.h
+++ b/src/basic/memory-util.h
@@ -121,3 +121,37 @@ static inline void erase_and_freep(void *p) {
 static inline void erase_char(char *p) {
         explicit_bzero_safe(p, sizeof(char));
 }
+
+/* An automatic _cleanup_-like logic for destroy arrays (i.e. pointers + size) when leaving scope */
+struct ArrayCleanup {
+        void **parray;
+        size_t *pn;
+        free_array_func_t pfunc;
+};
+
+static inline void array_cleanup(struct ArrayCleanup *c) {
+        assert(c);
+
+        assert(!c->parray == !c->pn);
+
+        if (!c->parray)
+                return;
+
+        if (*c->parray) {
+                assert(c->pfunc);
+                c->pfunc(*c->parray, *c->pn);
+                *c->parray = NULL;
+        }
+
+        *c->pn = 0;
+}
+
+#define CLEANUP_ARRAY(array, n, func)                                   \
+        _cleanup_(array_cleanup) _unused_ struct ArrayCleanup CONCATENATE(_cleanup_array_, UNIQ) = { \
+                .parray = (void**) &(array),                            \
+                .pn = &(n),                                             \
+                .pfunc = (free_array_func_t) ({                         \
+                                void (*_f)(typeof(array[0]) *a, size_t b) = func; \
+                                _f;                                     \
+                        }),                                             \
+        }

--- a/src/libsystemd/sd-journal/journal-vacuum.c
+++ b/src/libsystemd/sd-journal/journal-vacuum.c
@@ -47,6 +47,16 @@ static int vacuum_info_compare(const vacuum_info *a, const vacuum_info *b) {
         return strcmp(a->filename, b->filename);
 }
 
+static void vacuum_info_array_free(vacuum_info *list, size_t n) {
+        if (!list)
+                return;
+
+        FOREACH_ARRAY(i, list, n)
+                free(i->filename);
+
+        free(list);
+}
+
 static void patch_realtime(
                 int fd,
                 const char *fn,
@@ -129,6 +139,8 @@ int journal_directory_vacuum(
         usec_t retention_limit = 0;
         int r;
 
+        CLEANUP_ARRAY(list, n_list, vacuum_info_array_free);
+
         assert(directory);
 
         if (max_use <= 0 && max_retention_usec <= 0 && n_max_files <= 0)
@@ -141,7 +153,7 @@ int journal_directory_vacuum(
         if (!d)
                 return -errno;
 
-        FOREACH_DIRENT_ALL(de, d, r = -errno; goto finish) {
+        FOREACH_DIRENT_ALL(de, d, return -errno) {
                 unsigned long long seqnum = 0, realtime;
                 _cleanup_free_ char *p = NULL;
                 sd_id128_t seqnum_id;
@@ -182,10 +194,8 @@ int journal_directory_vacuum(
                         }
 
                         p = strdup(de->d_name);
-                        if (!p) {
-                                r = -ENOMEM;
-                                goto finish;
-                        }
+                        if (!p)
+                                return -ENOMEM;
 
                         de->d_name[q-8-16-1-16-1] = 0;
                         if (sd_id128_from_string(de->d_name + q-8-16-1-16-1-32, &seqnum_id) < 0) {
@@ -224,10 +234,8 @@ int journal_directory_vacuum(
                         }
 
                         p = strdup(de->d_name);
-                        if (!p) {
-                                r = -ENOMEM;
-                                goto finish;
-                        }
+                        if (!p)
+                                return -ENOMEM;
 
                         if (sscanf(de->d_name + q-1-8-16-1-16, "%16llx-%16llx.journal~", &realtime, &tmp) != 2) {
                                 n_active_files++;
@@ -265,10 +273,8 @@ int journal_directory_vacuum(
 
                 patch_realtime(dirfd(d), p, &st, &realtime);
 
-                if (!GREEDY_REALLOC(list, n_list + 1)) {
-                        r = -ENOMEM;
-                        goto finish;
-                }
+                if (!GREEDY_REALLOC(list, n_list + 1))
+                        return -ENOMEM;
 
                 list[n_list++] = (vacuum_info) {
                         .filename = TAKE_PTR(p),
@@ -312,15 +318,8 @@ int journal_directory_vacuum(
         if (oldest_usec && i < n_list && (*oldest_usec == 0 || list[i].realtime < *oldest_usec))
                 *oldest_usec = list[i].realtime;
 
-        r = 0;
-
-finish:
-        for (i = 0; i < n_list; i++)
-                free(list[i].filename);
-        free(list);
-
         log_full(verbose ? LOG_INFO : LOG_DEBUG, "Vacuuming done, freed %s of archived journals from %s.",
                  FORMAT_BYTES(freed), directory);
 
-        return r;
+        return 0;
 }

--- a/src/libsystemd/sd-journal/journal-vacuum.c
+++ b/src/libsystemd/sd-journal/journal-vacuum.c
@@ -19,7 +19,7 @@
 #include "time-util.h"
 #include "xattr-util.h"
 
-struct vacuum_info {
+typedef struct vacuum_info {
         uint64_t usage;
         char *filename;
 
@@ -28,9 +28,9 @@ struct vacuum_info {
         sd_id128_t seqnum_id;
         uint64_t seqnum;
         bool have_seqnum;
-};
+} vacuum_info;
 
-static int vacuum_compare(const struct vacuum_info *a, const struct vacuum_info *b) {
+static int vacuum_info_compare(const vacuum_info *a, const vacuum_info *b) {
         int r;
 
         if (a->have_seqnum && b->have_seqnum &&
@@ -125,7 +125,7 @@ int journal_directory_vacuum(
         uint64_t sum = 0, freed = 0, n_active_files = 0;
         size_t n_list = 0, i;
         _cleanup_closedir_ DIR *d = NULL;
-        struct vacuum_info *list = NULL;
+        vacuum_info *list = NULL;
         usec_t retention_limit = 0;
         int r;
 
@@ -270,7 +270,7 @@ int journal_directory_vacuum(
                         goto finish;
                 }
 
-                list[n_list++] = (struct vacuum_info) {
+                list[n_list++] = (vacuum_info) {
                         .filename = TAKE_PTR(p),
                         .usage = size,
                         .seqnum = seqnum,
@@ -282,7 +282,7 @@ int journal_directory_vacuum(
                 sum += size;
         }
 
-        typesafe_qsort(list, n_list, vacuum_compare);
+        typesafe_qsort(list, n_list, vacuum_info_compare);
 
         for (i = 0; i < n_list; i++) {
                 uint64_t left;

--- a/src/libsystemd/sd-journal/journal-vacuum.c
+++ b/src/libsystemd/sd-journal/journal-vacuum.c
@@ -158,6 +158,8 @@ int journal_directory_vacuum(
                 if (!S_ISREG(st.st_mode))
                         continue;
 
+                size = 512UL * (uint64_t) st.st_blocks;
+
                 q = strlen(de->d_name);
 
                 if (endswith(de->d_name, ".journal")) {
@@ -167,6 +169,7 @@ int journal_directory_vacuum(
 
                         if (q < 1 + 32 + 1 + 16 + 1 + 16 + 8) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -174,6 +177,7 @@ int journal_directory_vacuum(
                             de->d_name[q-8-16-1-16-1] != '-' ||
                             de->d_name[q-8-16-1-16-1-32-1] != '@') {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -186,11 +190,13 @@ int journal_directory_vacuum(
                         de->d_name[q-8-16-1-16-1] = 0;
                         if (sd_id128_from_string(de->d_name + q-8-16-1-16-1-32, &seqnum_id) < 0) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
                         if (sscanf(de->d_name + q-8-16-1-16, "%16llx-%16llx.journal", &seqnum, &realtime) != 2) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -206,12 +212,14 @@ int journal_directory_vacuum(
 
                         if (q < 1 + 16 + 1 + 16 + 8 + 1) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
                         if (de->d_name[q-1-8-16-1] != '-' ||
                             de->d_name[q-1-8-16-1-16-1] != '@') {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -223,6 +231,7 @@ int journal_directory_vacuum(
 
                         if (sscanf(de->d_name + q-1-8-16-1-16, "%16llx-%16llx.journal~", &realtime, &tmp) != 2) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -232,8 +241,6 @@ int journal_directory_vacuum(
                         log_debug("Not vacuuming unknown file %s.", de->d_name);
                         continue;
                 }
-
-                size = 512UL * (uint64_t) st.st_blocks;
 
                 r = journal_file_empty(dirfd(d), p);
                 if (r < 0) {

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -213,6 +213,8 @@ tests += [
          [],
          [libm]],
 
+        [files('test-memory-util.c')],
+
         [files('test-mkdir.c')],
 
         [files('test-json.c'),

--- a/src/test/test-macro.c
+++ b/src/test/test-macro.c
@@ -521,4 +521,54 @@ TEST(ISPOWEROF2) {
         assert_se(!ISPOWEROF2(u));
 }
 
+TEST(FOREACH_ARRAY) {
+        int a[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        int b[10] = { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+        int x, n;
+
+        x = n = 0;
+        FOREACH_ARRAY(i, a, 10) {
+                x += *i;
+                n++;
+        }
+        assert_se(x == 45);
+        assert_se(n == 10);
+
+        x = n = 0;
+        FOREACH_ARRAY(i, a, 10)
+                FOREACH_ARRAY(j, b, 10) {
+                        x += (*i) * (*j);
+                        n++;
+                }
+        assert_se(x == 45 * 45);
+        assert_se(n == 10 * 10);
+
+        x = n = 0;
+        FOREACH_ARRAY(i, a, 5)
+                FOREACH_ARRAY(j, b, 5) {
+                        x += (*i) * (*j);
+                        n++;
+                }
+        assert_se(x == 10 * 35);
+        assert_se(n == 5 * 5);
+
+        x = n = 0;
+        FOREACH_ARRAY(i, a, 0)
+                FOREACH_ARRAY(j, b, 0) {
+                        x += (*i) * (*j);
+                        n++;
+                }
+        assert_se(x == 0);
+        assert_se(n == 0);
+
+        x = n = 0;
+        FOREACH_ARRAY(i, a, -1)
+                FOREACH_ARRAY(j, b, -1) {
+                        x += (*i) * (*j);
+                        n++;
+                }
+        assert_se(x == 0);
+        assert_se(n == 0);
+}
+
 DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/test/test-memory-util.c
+++ b/src/test/test-memory-util.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "memory-util.h"
+#include "tests.h"
+
+static void my_destructor(struct iovec *iov, size_t n) {
+        /* not really a destructor, just something we can use to check if the destruction worked */
+        memset(iov, 'y', sizeof(struct iovec) * n);
+}
+
+TEST(cleanup_array) {
+        struct iovec *iov, *saved_iov;
+        size_t n, saved_n;
+
+        n = 7;
+        iov = new(struct iovec, n);
+        assert_se(iov);
+
+        memset(iov, 'x', sizeof(struct iovec) * n);
+
+        saved_iov = iov;
+        saved_n = n;
+
+        {
+                assert_se(memeqbyte('x', saved_iov, sizeof(struct iovec) * saved_n));
+                assert_se(iov);
+                assert_se(n > 0);
+
+                CLEANUP_ARRAY(iov, n, my_destructor);
+
+                assert_se(memeqbyte('x', saved_iov, sizeof(struct iovec) * saved_n));
+                assert_se(iov);
+                assert_se(n > 0);
+        }
+
+        assert_se(memeqbyte('y', saved_iov, sizeof(struct iovec) * saved_n));
+        assert_se(!iov);
+        assert_se(n == 0);
+
+        free(saved_iov);
+}
+
+DEFINE_TEST_MAIN(LOG_INFO);


### PR DESCRIPTION
Also includes follow-up cleanups. These are not really needed, but they've given me the opportunity to backport two new macros (`CLEANUP_ARRAY` and `FOREACH_ARRAY`) that we'll likely need sooner or later.

Resolves: [#2182632](https://bugzilla.redhat.com/show_bug.cgi?id=2182632)