### PR TITLE
(#2100440) ci: trigger `differential-shellcheck` workflow on push

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -3,6 +3,10 @@
 
 name: Differential ShellCheck
 on:
+  push:
+    branches:
+      - main
+      - rhel-9.*.0
   pull_request:
     branches:
       - main
@@ -18,15 +22,14 @@ jobs:
 
     permissions:
       security-events: write
-      pull-requests: write
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@1b1b75e42f0694c1012228513b21617a748c866e
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also, update `differential-shellcheck` to the latest version (`v4.0.2`) - https://github.com/redhat-plumbers-in-action/differential-shellcheck/releases Push events are supported since `v4.0.0`.

Fixes: https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/215

This should get rid of annoying messages from the `github-code-scanning` bot.

![Screenshot from 2023-03-22 07-00-32](https://user-images.githubusercontent.com/2879818/226815668-36272095-4f1d-4465-a0e8-f317b0abfc52.png)