### PR TITLE
(#2196479) manager: don't taint the host if cgroups v1 is used

### DIFF
--- a/man/org.freedesktop.systemd1.xml
+++ b/man/org.freedesktop.systemd1.xml
@@ -1590,12 +1590,6 @@ node /org/freedesktop/systemd1 {
         </varlistentry>
 
         <varlistentry>
-          <term><literal>cgroupsv1</literal></term>
-
-          <listitem><para>The system is using the old cgroup hierarchy.</para></listitem>
-        </varlistentry>
-
-        <varlistentry>
           <term><literal>local-hwclock</literal></term>
 
           <listitem><para>The local hardware clock (RTC) is configured to be in local time rather than

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -4491,9 +4491,6 @@ char* manager_taint_string(const Manager *m) {
         if (access("/proc/cgroups", F_OK) < 0)
                 stage[n++] = "cgroups-missing";
 
-        if (cg_all_unified() == 0)
-                stage[n++] = "cgroupsv1";
-
         if (clock_is_localtime(NULL) > 0)
                 stage[n++] = "local-hwclock";
 

--- a/src/test/test-manager.c
+++ b/src/test/test-manager.c
@@ -14,11 +14,6 @@ TEST(manager_taint_string) {
          * to test for them. Let's do just one. */
         assert_se(!strstr(a, "split-usr"));
 
-        if (cg_all_unified() == 0)
-                assert_se(strstr(a, "cgroupsv1"));
-        else
-                assert_se(!strstr(a, "cgroupsv1"));
-
         m.taint_usr = true;
         _cleanup_free_ char *b = manager_taint_string(&m);
         assert_se(b);


### PR DESCRIPTION
In upstream of systemd, cgroups v1 are not considered as supported. This is not true for RHEL, don't taint the host when cgroups v1 are enabled.

rhel-only

Resolves: #2196479

<!-- advanced-commit-linter = {"comment-id":"1634113286"} -->