### PR TITLE
(#2211065) Always use inactive_exit_timestamp if it is set

### DIFF
--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -401,12 +401,10 @@ static void timer_enter_waiting(Timer *t, bool time_change) {
 
                         if (t->last_trigger.realtime > 0)
                                 b = t->last_trigger.realtime;
-                        else {
-                                if (state_translation_table[t->state] == UNIT_ACTIVE)
-                                        b = UNIT(t)->inactive_exit_timestamp.realtime;
-                                else
-                                        b = ts.realtime;
-                        }
+                        else if (dual_timestamp_is_set(&UNIT(t)->inactive_exit_timestamp))
+                                b = UNIT(t)->inactive_exit_timestamp.realtime;
+                        else
+                                b = ts.realtime;
 
                         r = calendar_spec_next_usec(v->calendar_spec, b, &v->next_elapse);
                         if (r < 0)

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -399,7 +399,7 @@ static void timer_enter_waiting(Timer *t, bool time_change) {
                          * to that. If we don't, just start from
                          * the activation time. */
 
-                        if (t->last_trigger.realtime > 0)
+                        if (dual_timestamp_is_set(&t->last_trigger))
                                 b = t->last_trigger.realtime;
                         else if (dual_timestamp_is_set(&UNIT(t)->inactive_exit_timestamp))
                                 b = UNIT(t)->inactive_exit_timestamp.realtime;


### PR DESCRIPTION
Resolves: [#2211065](https://bugzilla.redhat.com/show_bug.cgi?id=2211065)

<!-- advanced-commit-linter = {"comment-id":"1568360949"} -->