### PR TITLE
(#2212612) rules: online CPU automatically on IBM s390x platforms

### DIFF
--- a/rules.d/40-redhat.rules
+++ b/rules.d/40-redhat.rules
@@ -3,7 +3,8 @@
 # CPU hotadd request
 SUBSYSTEM!="cpu", GOTO="cpu_online_end"
 ACTION!="add", GOTO="cpu_online_end"
-CONST{arch}=="s390*|ppc64*", GOTO="cpu_online_end"
+CONST{arch}=="ppc64*", GOTO="cpu_online_end"
+CONST{arch}=="s390*", ATTR{configure}=="0", GOTO="cpu_online_end"
 
 TEST=="online", ATTR{online}=="0", ATTR{online}="1"
 


### PR DESCRIPTION
RHEL-only

Fix CPU hotplug regression on s390x introduced by commit 94c7e260b499 ("rules: do not online CPU automatically on IBM platforms")

Resolves: #2212612

<!-- advanced-commit-linter = {"comment-id":"1601347933"} -->