### PR TITLE
(#2210145) pam: add call to pam_umask

### DIFF
--- a/src/login/systemd-user.in
+++ b/src/login/systemd-user.in
@@ -18,4 +18,5 @@ session optional pam_keyinit.so force revoke
 {% if ENABLE_HOMED %}
 -session optional pam_systemd_home.so
 {% endif %}
+session optional pam_umask.so silent
 session optional pam_systemd.so


### PR DESCRIPTION
Setting umask for user sessions via UMASK setting in /etc/login.defs is a well-known feature. Let's make sure that user manager also runs with this umask value.

Follow-up for 5e37d1930b41b24c077ce37c6db0e36c745106c7.

(cherry picked from commit 159f1b78576ce91c3932f4867f07361a530875d3)

Resolves: #2210145

<!-- advanced-commit-linter = {"comment-id":"1611182585"} -->