### PR TITLE
(#2218184) pam: add a call to pam_namespace

### DIFF
--- a/src/login/systemd-user.in
+++ b/src/login/systemd-user.in
@@ -15,6 +15,7 @@ session required pam_selinux.so nottys open
 {% endif %}
 session required pam_loginuid.so
 session optional pam_keyinit.so force revoke
+session required pam_namespace.so
 {% if ENABLE_HOMED %}
 -session optional pam_systemd_home.so
 {% endif %}


### PR DESCRIPTION
A call to pam_namespace is required so that children of user@.service end up in a namespace as expected. pam_namespace gets called as part of the stack that creates a session (login, sshd, gdm, etc.) and those processes end up in a namespace, but it also needs to be called from our stack which is parallel and descends from pid1 itself.

The call to pam_namespace is similar to the call to pam_keyinit that was added in ab79099d1684457d040ee7c28b2012e8c1ea9a4f. The pam stack for user@.service creates a new session which is disconnected from the parent environment. Both calls are not suitable for inclusion in the shared part of the stack (e.g. @system-auth on Fedora/RHEL systems), because for example su/sudo/runuser should not include them.

Fixes #17043 (Allow to execute user service into dedicated namespace
              if pam_namespace enabled)
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1861836 (Polyinstantiation is ignored/bypassed in GNOME sessions)

(cherry picked from commit 0ef48896d9f23b9fd547a532a4e6e6b8f8b12901)

Resolves: #2218184

<!-- advanced-commit-linter = {"comment-id":"1611352308"} -->