### PR TITLE
(#2170883) Allow `RHEL-only` labels to mark downstream-only commits

### DIFF
--- a/.github/advanced-commit-linter.yml
+++ b/.github/advanced-commit-linter.yml
@@ -6,6 +6,7 @@ policy:
     exception:
       note:
         - rhel-only
+        - RHEL-only
   tracker:
     - keyword:
         - 'Resolves: #?'


### PR DESCRIPTION


<!-- advanced-commit-linter = {"comment-id":"1628681929"} -->