### PR TITLE
(#2170883) ci: drop systemd-stable from advanced-commit-linter config

### DIFF
--- a/.github/advanced-commit-linter.yml
+++ b/.github/advanced-commit-linter.yml
@@ -2,7 +2,6 @@ policy:
   cherry-pick:
     upstream:
       - github: systemd/systemd
-      - github: systemd/systemd-stable
     exception:
       note:
         - rhel-only


### PR DESCRIPTION
It's sufficient enough to check only the `systemd/systemd` repo.

Related to https://github.com/redhat-plumbers-in-action/advanced-commit-linter/issues/62

rhel-only

Related: #2170883

<!-- advanced-commit-linter = {"comment-id":"1634225594"} -->