### PR TITLE
Revert "core/service: when resetting PID also reset known flag"

### DIFF
--- a/.github/workflows/build_test.sh
+++ b/.github/workflows/build_test.sh
@@ -86,7 +86,7 @@ if [[ "$COMPILER" == clang ]]; then
                "$RELEASE" "$RELEASE" "$COMPILER_VERSION" >/etc/apt/sources.list.d/llvm-toolchain.list
     fi
 
-    PACKAGES+=("clang-$COMPILER_VERSION" "lldb-$COMPILER_VERSION" "lld-$COMPILER_VERSION" "clangd-$COMPILER_VERSION")
+    PACKAGES+=("clang-$COMPILER_VERSION" "lldb-$COMPILER_VERSION" "python3-lldb-$COMPILER_VERSION" "lld-$COMPILER_VERSION" "clangd-$COMPILER_VERSION")
 elif [[ "$COMPILER" == gcc ]]; then
     CC="gcc-$COMPILER_VERSION"
     CXX="g++-$COMPILER_VERSION"

--- a/src/core/service.c
+++ b/src/core/service.c
@@ -3507,7 +3507,6 @@ static void service_sigchld_event(Unit *u, pid_t pid, int code, int status) {
                         return;
 
                 s->main_pid = 0;
-                s->main_pid_known = false;
                 exec_status_exit(&s->main_exec_status, &s->exec_context, pid, code, status);
 
                 if (s->main_command) {


### PR DESCRIPTION
This reverts commit ff32060f2ed37b68dc26256b05e2e69013b0ecfe.

This change is incorrect as we don't want to mark the PID as invalid but only mark it as dead.

The change in question also breaks user level socket activation for `podman.service` as the termination of the main `podman system service` process is not properly handled, causing any application accessing the socket to hang.

This is because the user-level `podman.service` unit also hosts two non-main processes: `rootlessport` and `rootlessport-child` which causes the `cgroup_good` check to still succeed.

The original submitter of this commit is recommended to find another more correct way to fix the cgroupsv1 issue on CentOS 8.

(cherry picked from commit 996b00ede87d6a870332e63974a7d4def3c2f1b0)

Resolves: #2225667
Reverts: #2210237

<!-- advanced-commit-linter = {"comment-id":"1659743363"} -->