### PR TITLE
(RHEL-5988) Assign alternative names only on add uevent

### DIFF
--- a/src/core/device.c
+++ b/src/core/device.c
@@ -1108,6 +1108,25 @@ static int device_dispatch_io(sd_device_monitor *monitor, sd_device *dev, void *
         if (action == SD_DEVICE_MOVE)
                 device_remove_old_on_move(m, dev);
 
+        /* When udevd failed to process the device, SYSTEMD_ALIAS or any other properties may contain invalid
+         * values. Let's refuse to handle the uevent. */
+        if (sd_device_get_property_value(dev, "UDEV_WORKER_FAILED", NULL) >= 0) {
+                int v;
+
+                if (device_get_property_int(dev, "UDEV_WORKER_ERRNO", &v) >= 0)
+                        log_device_warning_errno(dev, v, "systemd-udevd failed to process the device, ignoring: %m");
+                else if (device_get_property_int(dev, "UDEV_WORKER_EXIT_STATUS", &v) >= 0)
+                        log_device_warning(dev, "systemd-udevd failed to process the device with exit status %i, ignoring.", v);
+                else if (device_get_property_int(dev, "UDEV_WORKER_SIGNAL", &v) >= 0) {
+                        const char *s;
+                        (void) sd_device_get_property_value(dev, "UDEV_WORKER_SIGNAL_NAME", &s);
+                        log_device_warning(dev, "systemd-udevd failed to process the device with signal %i(%s), ignoring.", v, strna(s));
+                } else
+                        log_device_warning(dev, "systemd-udevd failed to process the device with unknown result, ignoring.");
+
+                return 0;
+        }
+
         /* A change event can signal that a device is becoming ready, in particular if the device is using
          * the SYSTEMD_READY logic in udev so we need to reach the else block of the following if, even for
          * change events */

--- a/src/core/device.c
+++ b/src/core/device.c
@@ -1095,13 +1095,13 @@ static int device_dispatch_io(sd_device_monitor *monitor, sd_device *dev, void *
 
         r = sd_device_get_syspath(dev, &sysfs);
         if (r < 0) {
-                log_device_error_errno(dev, r, "Failed to get device syspath, ignoring: %m");
+                log_device_warning_errno(dev, r, "Failed to get device syspath, ignoring: %m");
                 return 0;
         }
 
         r = sd_device_get_action(dev, &action);
         if (r < 0) {
-                log_device_error_errno(dev, r, "Failed to get udev action, ignoring: %m");
+                log_device_warning_errno(dev, r, "Failed to get udev action, ignoring: %m");
                 return 0;
         }
 

--- a/src/libsystemd/sd-device/device-private.c
+++ b/src/libsystemd/sd-device/device-private.c
@@ -619,51 +619,6 @@ int device_get_devlink_priority(sd_device *device, int *ret) {
         return 0;
 }
 
-int device_rename(sd_device *device, const char *name) {
-        _cleanup_free_ char *new_syspath = NULL;
-        const char *s;
-        int r;
-
-        assert(device);
-        assert(name);
-
-        if (!filename_is_valid(name))
-                return -EINVAL;
-
-        r = sd_device_get_syspath(device, &s);
-        if (r < 0)
-                return r;
-
-        r = path_extract_directory(s, &new_syspath);
-        if (r < 0)
-                return r;
-
-        if (!path_extend(&new_syspath, name))
-                return -ENOMEM;
-
-        if (!path_is_safe(new_syspath))
-                return -EINVAL;
-
-        /* At the time this is called, the renamed device may not exist yet. Hence, we cannot validate
-         * the new syspath. */
-        r = device_set_syspath(device, new_syspath, /* verify = */ false);
-        if (r < 0)
-                return r;
-
-        r = sd_device_get_property_value(device, "INTERFACE", &s);
-        if (r == -ENOENT)
-                return 0;
-        if (r < 0)
-                return r;
-
-        /* like DEVPATH_OLD, INTERFACE_OLD is not saved to the db, but only stays around for the current event */
-        r = device_add_property_internal(device, "INTERFACE_OLD", s);
-        if (r < 0)
-                return r;
-
-        return device_add_property_internal(device, "INTERFACE", name);
-}
-
 static int device_shallow_clone(sd_device *device, sd_device **ret) {
         _cleanup_(sd_device_unrefp) sd_device *dest = NULL;
         const char *val = NULL;

--- a/src/libsystemd/sd-device/device-private.c
+++ b/src/libsystemd/sd-device/device-private.c
@@ -621,7 +621,7 @@ int device_get_devlink_priority(sd_device *device, int *ret) {
 
 int device_rename(sd_device *device, const char *name) {
         _cleanup_free_ char *new_syspath = NULL;
-        const char *interface;
+        const char *s;
         int r;
 
         assert(device);
@@ -630,7 +630,11 @@ int device_rename(sd_device *device, const char *name) {
         if (!filename_is_valid(name))
                 return -EINVAL;
 
-        r = path_extract_directory(device->syspath, &new_syspath);
+        r = sd_device_get_syspath(device, &s);
+        if (r < 0)
+                return r;
+
+        r = path_extract_directory(s, &new_syspath);
         if (r < 0)
                 return r;
 
@@ -642,18 +646,18 @@ int device_rename(sd_device *device, const char *name) {
 
         /* At the time this is called, the renamed device may not exist yet. Hence, we cannot validate
          * the new syspath. */
-        r = device_set_syspath(device, new_syspath, false);
+        r = device_set_syspath(device, new_syspath, /* verify = */ false);
         if (r < 0)
                 return r;
 
-        r = sd_device_get_property_value(device, "INTERFACE", &interface);
+        r = sd_device_get_property_value(device, "INTERFACE", &s);
         if (r == -ENOENT)
                 return 0;
         if (r < 0)
                 return r;
 
         /* like DEVPATH_OLD, INTERFACE_OLD is not saved to the db, but only stays around for the current event */
-        r = device_add_property_internal(device, "INTERFACE_OLD", interface);
+        r = device_add_property_internal(device, "INTERFACE_OLD", s);
         if (r < 0)
                 return r;
 

--- a/src/libsystemd/sd-device/device-private.c
+++ b/src/libsystemd/sd-device/device-private.c
@@ -646,10 +646,6 @@ int device_rename(sd_device *device, const char *name) {
         if (r < 0)
                 return r;
 
-        /* Here, only clear the sysname and sysnum. They will be set when requested. */
-        device->sysnum = NULL;
-        device->sysname = mfree(device->sysname);
-
         r = sd_device_get_property_value(device, "INTERFACE", &interface);
         if (r == -ENOENT)
                 return 0;

--- a/src/libsystemd/sd-device/device-private.h
+++ b/src/libsystemd/sd-device/device-private.h
@@ -18,6 +18,7 @@ int device_new_from_strv(sd_device **ret, char **strv);
 int device_opendir(sd_device *device, const char *subdir, DIR **ret);
 
 int device_get_property_bool(sd_device *device, const char *key);
+int device_get_property_int(sd_device *device, const char *key, int *ret);
 int device_get_sysattr_int(sd_device *device, const char *sysattr, int *ret_value);
 int device_get_sysattr_unsigned(sd_device *device, const char *sysattr, unsigned *ret_value);
 int device_get_sysattr_bool(sd_device *device, const char *sysattr);

--- a/src/libsystemd/sd-device/device-private.h
+++ b/src/libsystemd/sd-device/device-private.h
@@ -53,7 +53,6 @@ int device_properties_prepare(sd_device *device);
 int device_get_properties_nulstr(sd_device *device, const char **ret_nulstr, size_t *ret_len);
 int device_get_properties_strv(sd_device *device, char ***ret);
 
-int device_rename(sd_device *device, const char *name);
 int device_clone_with_db(sd_device *device, sd_device **ret);
 
 int device_tag_index(sd_device *dev, sd_device *dev_old, bool add);

--- a/src/libsystemd/sd-device/sd-device.c
+++ b/src/libsystemd/sd-device/sd-device.c
@@ -2186,6 +2186,26 @@ int device_get_property_bool(sd_device *device, const char *key) {
         return parse_boolean(value);
 }
 
+int device_get_property_int(sd_device *device, const char *key, int *ret) {
+        const char *value;
+        int r, v;
+
+        assert(device);
+        assert(key);
+
+        r = sd_device_get_property_value(device, key, &value);
+        if (r < 0)
+                return r;
+
+        r = safe_atoi(value, &v);
+        if (r < 0)
+                return r;
+
+        if (ret)
+                *ret = v;
+        return 0;
+}
+
 _public_ int sd_device_get_trigger_uuid(sd_device *device, sd_id128_t *ret) {
         const char *s;
         sd_id128_t id;

--- a/src/libsystemd/sd-device/sd-device.c
+++ b/src/libsystemd/sd-device/sd-device.c
@@ -250,6 +250,10 @@ int device_set_syspath(sd_device *device, const char *_syspath, bool verify) {
 
         free_and_replace(device->syspath, syspath);
         device->devpath = devpath;
+
+        /* Unset sysname and sysnum, they will be assigned when requested. */
+        device->sysnum = NULL;
+        device->sysname = mfree(device->sysname);
         return 0;
 }
 

--- a/src/libsystemd/sd-netlink/netlink-util.c
+++ b/src/libsystemd/sd-netlink/netlink-util.c
@@ -14,6 +14,7 @@
 int rtnl_set_link_name(sd_netlink **rtnl, int ifindex, const char *name) {
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL;
         _cleanup_strv_free_ char **alternative_names = NULL;
+        bool altname_deleted = false;
         int r;
 
         assert(rtnl);
@@ -33,21 +34,33 @@ int rtnl_set_link_name(sd_netlink **rtnl, int ifindex, const char *name) {
                 if (r < 0)
                         return log_debug_errno(r, "Failed to remove '%s' from alternative names on network interface %i: %m",
                                                name, ifindex);
+
+                altname_deleted = true;
         }
 
         r = sd_rtnl_message_new_link(*rtnl, &message, RTM_SETLINK, ifindex);
         if (r < 0)
-                return r;
+                goto fail;
 
         r = sd_netlink_message_append_string(message, IFLA_IFNAME, name);
         if (r < 0)
-                return r;
+                goto fail;
 
         r = sd_netlink_call(*rtnl, message, 0, NULL);
         if (r < 0)
-                return r;
+                goto fail;
 
         return 0;
+
+fail:
+        if (altname_deleted) {
+                int q = rtnl_set_link_alternative_names(rtnl, ifindex, STRV_MAKE(name));
+                if (q < 0)
+                        log_debug_errno(q, "Failed to restore '%s' as an alternative name on network interface %i, ignoring: %m",
+                                        name, ifindex);
+        }
+
+        return r;
 }
 
 int rtnl_set_link_properties(

--- a/src/libsystemd/sd-netlink/netlink-util.c
+++ b/src/libsystemd/sd-netlink/netlink-util.c
@@ -11,44 +11,93 @@
 #include "process-util.h"
 #include "strv.h"
 
-int rtnl_set_link_name(sd_netlink **rtnl, int ifindex, const char *name) {
+static int set_link_name(sd_netlink **rtnl, int ifindex, const char *name) {
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL;
-        _cleanup_strv_free_ char **alternative_names = NULL;
-        bool altname_deleted = false;
         int r;
 
         assert(rtnl);
         assert(ifindex > 0);
         assert(name);
 
-        if (!ifname_valid(name))
+        /* Assign the requested name. */
+        r = sd_rtnl_message_new_link(*rtnl, &message, RTM_SETLINK, ifindex);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_message_append_string(message, IFLA_IFNAME, name);
+        if (r < 0)
+                return r;
+
+        return sd_netlink_call(*rtnl, message, 0, NULL);
+}
+
+int rtnl_set_link_name(sd_netlink **rtnl, int ifindex, const char *name, char* const *alternative_names) {
+        _cleanup_strv_free_ char **original_altnames = NULL, **new_altnames = NULL;
+        bool altname_deleted = false;
+        int r;
+
+        assert(rtnl);
+        assert(ifindex > 0);
+
+        if (isempty(name) && strv_isempty(alternative_names))
+                return 0;
+
+        if (name && !ifname_valid(name))
                 return -EINVAL;
 
-        r = rtnl_get_link_alternative_names(rtnl, ifindex, &alternative_names);
+        /* If the requested name is already assigned as an alternative name, then first drop it. */
+        r = rtnl_get_link_alternative_names(rtnl, ifindex, &original_altnames);
         if (r < 0)
                 log_debug_errno(r, "Failed to get alternative names on network interface %i, ignoring: %m",
                                 ifindex);
 
-        if (strv_contains(alternative_names, name)) {
-                r = rtnl_delete_link_alternative_names(rtnl, ifindex, STRV_MAKE(name));
-                if (r < 0)
-                        return log_debug_errno(r, "Failed to remove '%s' from alternative names on network interface %i: %m",
-                                               name, ifindex);
+        if (name) {
+                if (strv_contains(original_altnames, name)) {
+                        r = rtnl_delete_link_alternative_names(rtnl, ifindex, STRV_MAKE(name));
+                        if (r < 0)
+                                return log_debug_errno(r, "Failed to remove '%s' from alternative names on network interface %i: %m",
+                                                       name, ifindex);
 
-                altname_deleted = true;
+                        altname_deleted = true;
+                }
+
+                r = set_link_name(rtnl, ifindex, name);
+                if (r < 0)
+                        goto fail;
         }
 
-        r = sd_rtnl_message_new_link(*rtnl, &message, RTM_SETLINK, ifindex);
-        if (r < 0)
-                goto fail;
+        /* Filter out already assigned names from requested alternative names. Also, dedup the request. */
+        STRV_FOREACH(a, alternative_names) {
+                if (streq_ptr(name, *a))
+                        continue;
 
-        r = sd_netlink_message_append_string(message, IFLA_IFNAME, name);
-        if (r < 0)
-                goto fail;
+                if (strv_contains(original_altnames, *a))
+                        continue;
 
-        r = sd_netlink_call(*rtnl, message, 0, NULL);
-        if (r < 0)
-                goto fail;
+                if (strv_contains(new_altnames, *a))
+                        continue;
+
+                if (!ifname_valid_full(*a, IFNAME_VALID_ALTERNATIVE))
+                        continue;
+
+                r = strv_extend(&new_altnames, *a);
+                if (r < 0)
+                        return r;
+        }
+
+        strv_sort(new_altnames);
+
+        /* Finally, assign alternative names. */
+        r = rtnl_set_link_alternative_names(rtnl, ifindex, new_altnames);
+        if (r == -EEXIST) /* Already assigned to another interface? */
+                STRV_FOREACH(a, new_altnames) {
+                        r = rtnl_set_link_alternative_names(rtnl, ifindex, STRV_MAKE(*a));
+                        if (r < 0)
+                                log_debug_errno(r, "Failed to assign '%s' as an alternative name on network interface %i, ignoring: %m",
+                                                *a, ifindex);
+                }
+        else if (r < 0)
+                log_debug_errno(r, "Failed to assign alternative names on network interface %i, ignoring: %m", ifindex);
 
         return 0;
 

--- a/src/libsystemd/sd-netlink/netlink-util.h
+++ b/src/libsystemd/sd-netlink/netlink-util.h
@@ -29,7 +29,10 @@ DEFINE_TRIVIAL_CLEANUP_FUNC(MultipathRoute*, multipath_route_free);
 
 int multipath_route_dup(const MultipathRoute *m, MultipathRoute **ret);
 
-int rtnl_set_link_name(sd_netlink **rtnl, int ifindex, const char *name);
+int rtnl_set_link_name(sd_netlink **rtnl, int ifindex, const char *name, char* const* alternative_names);
+static inline int rtnl_append_link_alternative_names(sd_netlink **rtnl, int ifindex, char* const *alternative_names) {
+        return rtnl_set_link_name(rtnl, ifindex, NULL, alternative_names);
+}
 int rtnl_set_link_properties(
                 sd_netlink **rtnl,
                 int ifindex,

--- a/src/libsystemd/sd-netlink/test-netlink.c
+++ b/src/libsystemd/sd-netlink/test-netlink.c
@@ -24,11 +24,12 @@
 #include "strv.h"
 #include "tests.h"
 
-static void test_message_link_bridge(sd_netlink *rtnl) {
+TEST(message_newlink_bridge) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL;
         uint32_t cost;
 
-        log_debug("/* %s */", __func__);
+        assert_se(sd_netlink_open(&rtnl) >= 0);
 
         assert_se(sd_rtnl_message_new_link(rtnl, &message, RTM_NEWLINK, 1) >= 0);
         assert_se(sd_rtnl_message_link_set_family(message, AF_BRIDGE) >= 0);
@@ -44,99 +45,81 @@ static void test_message_link_bridge(sd_netlink *rtnl) {
         assert_se(sd_netlink_message_exit_container(message) >= 0);
 }
 
-static void test_link_configure(sd_netlink *rtnl, int ifindex) {
+TEST(message_getlink) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL, *reply = NULL;
-        uint32_t mtu_out;
-        const char *name_out;
-        struct ether_addr mac_out;
+        int ifindex;
+        uint8_t u8_data;
+        uint16_t u16_data;
+        uint32_t u32_data;
+        const char *str_data;
+        struct ether_addr eth_data;
 
-        log_debug("/* %s */", __func__);
+        assert_se(sd_netlink_open(&rtnl) >= 0);
+        ifindex = (int) if_nametoindex("lo");
 
         /* we'd really like to test NEWLINK, but let's not mess with the running kernel */
         assert_se(sd_rtnl_message_new_link(rtnl, &message, RTM_GETLINK, ifindex) >= 0);
-
         assert_se(sd_netlink_call(rtnl, message, 0, &reply) == 1);
 
-        assert_se(sd_netlink_message_read_string(reply, IFLA_IFNAME, &name_out) >= 0);
-        assert_se(sd_netlink_message_read_ether_addr(reply, IFLA_ADDRESS, &mac_out) >= 0);
-        assert_se(sd_netlink_message_read_u32(reply, IFLA_MTU, &mtu_out) >= 0);
+        /* u8 */
+        assert_se(sd_netlink_message_read_u8(reply, IFLA_CARRIER, &u8_data) >= 0);
+        assert_se(sd_netlink_message_read_u8(reply, IFLA_OPERSTATE, &u8_data) >= 0);
+        assert_se(sd_netlink_message_read_u8(reply, IFLA_LINKMODE, &u8_data) >= 0);
+
+        /* u16 */
+        assert_se(sd_netlink_message_get_type(reply, &u16_data) >= 0);
+        assert_se(u16_data == RTM_NEWLINK);
+
+        /* u32 */
+        assert_se(sd_netlink_message_read_u32(reply, IFLA_MTU, &u32_data) >= 0);
+        assert_se(sd_netlink_message_read_u32(reply, IFLA_GROUP, &u32_data) >= 0);
+        assert_se(sd_netlink_message_read_u32(reply, IFLA_TXQLEN, &u32_data) >= 0);
+        assert_se(sd_netlink_message_read_u32(reply, IFLA_NUM_TX_QUEUES, &u32_data) >= 0);
+        assert_se(sd_netlink_message_read_u32(reply, IFLA_NUM_RX_QUEUES, &u32_data) >= 0);
+
+        /* string */
+        assert_se(sd_netlink_message_read_string(reply, IFLA_IFNAME, &str_data) >= 0);
+
+        /* ether_addr */
+        assert_se(sd_netlink_message_read_ether_addr(reply, IFLA_ADDRESS, &eth_data) >= 0);
 }
 
-static void test_link_get(sd_netlink *rtnl, int ifindex) {
-        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL, *r = NULL;
-        const char *str_data;
-        uint8_t u8_data;
-        uint32_t u32_data;
-        struct ether_addr eth_data;
-
-        log_debug("/* %s */", __func__);
-
-        assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_GETLINK, ifindex) >= 0);
-        assert_se(m);
-
-        assert_se(sd_netlink_call(rtnl, m, 0, &r) == 1);
-
-        assert_se(sd_netlink_message_read_string(r, IFLA_IFNAME, &str_data) == 0);
-
-        assert_se(sd_netlink_message_read_u8(r, IFLA_CARRIER, &u8_data) == 0);
-        assert_se(sd_netlink_message_read_u8(r, IFLA_OPERSTATE, &u8_data) == 0);
-        assert_se(sd_netlink_message_read_u8(r, IFLA_LINKMODE, &u8_data) == 0);
-
-        assert_se(sd_netlink_message_read_u32(r, IFLA_MTU, &u32_data) == 0);
-        assert_se(sd_netlink_message_read_u32(r, IFLA_GROUP, &u32_data) == 0);
-        assert_se(sd_netlink_message_read_u32(r, IFLA_TXQLEN, &u32_data) == 0);
-        assert_se(sd_netlink_message_read_u32(r, IFLA_NUM_TX_QUEUES, &u32_data) == 0);
-        assert_se(sd_netlink_message_read_u32(r, IFLA_NUM_RX_QUEUES, &u32_data) == 0);
-
-        assert_se(sd_netlink_message_read_ether_addr(r, IFLA_ADDRESS, &eth_data) == 0);
-}
-
-static void test_address_get(sd_netlink *rtnl, int ifindex) {
-        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL, *r = NULL;
+TEST(message_address) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL, *reply = NULL;
+        int ifindex;
         struct in_addr in_data;
         struct ifa_cacheinfo cache;
         const char *label;
 
-        log_debug("/* %s */", __func__);
+        assert_se(sd_netlink_open(&rtnl) >= 0);
+        ifindex = (int) if_nametoindex("lo");
 
-        assert_se(sd_rtnl_message_new_addr(rtnl, &m, RTM_GETADDR, ifindex, AF_INET) >= 0);
-        assert_se(m);
-        assert_se(sd_netlink_message_set_request_dump(m, true) >= 0);
-        assert_se(sd_netlink_call(rtnl, m, -1, &r) == 1);
+        assert_se(sd_rtnl_message_new_addr(rtnl, &message, RTM_GETADDR, ifindex, AF_INET) >= 0);
+        assert_se(sd_netlink_message_set_request_dump(message, true) >= 0);
+        assert_se(sd_netlink_call(rtnl, message, 0, &reply) == 1);
 
-        assert_se(sd_netlink_message_read_in_addr(r, IFA_LOCAL, &in_data) == 0);
-        assert_se(sd_netlink_message_read_in_addr(r, IFA_ADDRESS, &in_data) == 0);
-        assert_se(sd_netlink_message_read_string(r, IFA_LABEL, &label) == 0);
-        assert_se(sd_netlink_message_read_cache_info(r, IFA_CACHEINFO, &cache) == 0);
+        assert_se(sd_netlink_message_read_in_addr(reply, IFA_LOCAL, &in_data) >= 0);
+        assert_se(sd_netlink_message_read_in_addr(reply, IFA_ADDRESS, &in_data) >= 0);
+        assert_se(sd_netlink_message_read_string(reply, IFA_LABEL, &label) >= 0);
+        assert_se(sd_netlink_message_read_cache_info(reply, IFA_CACHEINFO, &cache) == 0);
 }
 
-static void test_route(sd_netlink *rtnl) {
+TEST(message_route) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL;
         struct in_addr addr, addr_data;
         uint32_t index = 2, u32_data;
-        int r;
 
-        log_debug("/* %s */", __func__);
+        assert_se(sd_netlink_open(&rtnl) >= 0);
 
-        r = sd_rtnl_message_new_route(rtnl, &req, RTM_NEWROUTE, AF_INET, RTPROT_STATIC);
-        if (r < 0) {
-                log_error_errno(r, "Could not create RTM_NEWROUTE message: %m");
-                return;
-        }
+        assert_se(sd_rtnl_message_new_route(rtnl, &req, RTM_NEWROUTE, AF_INET, RTPROT_STATIC) >= 0);
 
         addr.s_addr = htobe32(INADDR_LOOPBACK);
 
-        r = sd_netlink_message_append_in_addr(req, RTA_GATEWAY, &addr);
-        if (r < 0) {
-                log_error_errno(r, "Could not append RTA_GATEWAY attribute: %m");
-                return;
-        }
-
-        r = sd_netlink_message_append_u32(req, RTA_OIF, index);
-        if (r < 0) {
-                log_error_errno(r, "Could not append RTA_OIF attribute: %m");
-                return;
-        }
+        assert_se(sd_netlink_message_append_in_addr(req, RTA_GATEWAY, &addr) >= 0);
+        assert_se(sd_netlink_message_append_u32(req, RTA_OIF, index) >= 0);
 
         assert_se(sd_netlink_message_rewind(req, rtnl) >= 0);
 
@@ -149,135 +132,94 @@ static void test_route(sd_netlink *rtnl) {
         assert_se((req = sd_netlink_message_unref(req)) == NULL);
 }
 
-static void test_multiple(void) {
-        sd_netlink *rtnl1, *rtnl2;
-
-        log_debug("/* %s */", __func__);
-
-        assert_se(sd_netlink_open(&rtnl1) >= 0);
-        assert_se(sd_netlink_open(&rtnl2) >= 0);
-
-        rtnl1 = sd_netlink_unref(rtnl1);
-        rtnl2 = sd_netlink_unref(rtnl2);
-}
-
 static int link_handler(sd_netlink *rtnl, sd_netlink_message *m, void *userdata) {
-        char *ifname = userdata;
         const char *data;
 
         assert_se(rtnl);
         assert_se(m);
-        assert_se(userdata);
 
-        log_info("%s: got link info about %s", __func__, ifname);
-        free(ifname);
+        assert_se(streq_ptr(userdata, "foo"));
 
         assert_se(sd_netlink_message_read_string(m, IFLA_IFNAME, &data) >= 0);
         assert_se(streq(data, "lo"));
 
+        log_info("%s: got link info about %s", __func__, data);
         return 1;
 }
 
-static void test_event_loop(int ifindex) {
+TEST(netlink_event_loop) {
         _cleanup_(sd_event_unrefp) sd_event *event = NULL;
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
-        char *ifname;
-
-        log_debug("/* %s */", __func__);
-
-        ifname = strdup("lo2");
-        assert_se(ifname);
+        _cleanup_free_ char *userdata = NULL;
+        int ifindex;
 
         assert_se(sd_netlink_open(&rtnl) >= 0);
-        assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_GETLINK, ifindex) >= 0);
+        ifindex = (int) if_nametoindex("lo");
 
-        assert_se(sd_netlink_call_async(rtnl, NULL, m, link_handler, NULL, ifname, 0, NULL) >= 0);
+        assert_se(userdata = strdup("foo"));
 
         assert_se(sd_event_default(&event) >= 0);
-
         assert_se(sd_netlink_attach_event(rtnl, event, 0) >= 0);
+
+        assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_GETLINK, ifindex) >= 0);
+        assert_se(sd_netlink_call_async(rtnl, NULL, m, link_handler, NULL, userdata, 0, NULL) >= 0);
 
         assert_se(sd_event_run(event, 0) >= 0);
 
         assert_se(sd_netlink_detach_event(rtnl) >= 0);
-
         assert_se((rtnl = sd_netlink_unref(rtnl)) == NULL);
 }
 
 static void test_async_destroy(void *userdata) {
 }
 
-static void test_async(int ifindex) {
+TEST(netlink_call_async) {
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
-        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL, *r = NULL;
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL, *reply = NULL;
         _cleanup_(sd_netlink_slot_unrefp) sd_netlink_slot *slot = NULL;
+        _cleanup_free_ char *userdata = NULL;
         sd_netlink_destroy_t destroy_callback;
         const char *description;
-        char *ifname;
-
-        log_debug("/* %s */", __func__);
-
-        ifname = strdup("lo");
-        assert_se(ifname);
+        int ifindex;
 
         assert_se(sd_netlink_open(&rtnl) >= 0);
+        ifindex = (int) if_nametoindex("lo");
+
+        assert_se(userdata = strdup("foo"));
 
         assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_GETLINK, ifindex) >= 0);
-
-        assert_se(sd_netlink_call_async(rtnl, &slot, m, link_handler, test_async_destroy, ifname, 0, "hogehoge") >= 0);
+        assert_se(sd_netlink_call_async(rtnl, &slot, m, link_handler, test_async_destroy, userdata, 0, "hogehoge") >= 0);
 
         assert_se(sd_netlink_slot_get_netlink(slot) == rtnl);
-        assert_se(sd_netlink_slot_get_userdata(slot) == ifname);
+
+        assert_se(sd_netlink_slot_get_userdata(slot) == userdata);
+        assert_se(sd_netlink_slot_set_userdata(slot, NULL) == userdata);
+        assert_se(sd_netlink_slot_get_userdata(slot) == NULL);
+        assert_se(sd_netlink_slot_set_userdata(slot, userdata) == NULL);
+        assert_se(sd_netlink_slot_get_userdata(slot) == userdata);
+
         assert_se(sd_netlink_slot_get_destroy_callback(slot, &destroy_callback) == 1);
         assert_se(destroy_callback == test_async_destroy);
-        assert_se(sd_netlink_slot_get_floating(slot) == 0);
-        assert_se(sd_netlink_slot_get_description(slot, &description) == 1);
-        assert_se(streq(description, "hogehoge"));
-
-        assert_se(sd_netlink_wait(rtnl, 0) >= 0);
-        assert_se(sd_netlink_process(rtnl, &r) >= 0);
-
-        assert_se((rtnl = sd_netlink_unref(rtnl)) == NULL);
-}
-
-static void test_slot_set(int ifindex) {
-        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
-        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL, *r = NULL;
-        _cleanup_(sd_netlink_slot_unrefp) sd_netlink_slot *slot = NULL;
-        sd_netlink_destroy_t destroy_callback;
-        const char *description;
-        char *ifname;
-
-        log_debug("/* %s */", __func__);
-
-        ifname = strdup("lo");
-        assert_se(ifname);
-
-        assert_se(sd_netlink_open(&rtnl) >= 0);
-
-        assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_GETLINK, ifindex) >= 0);
-
-        assert_se(sd_netlink_call_async(rtnl, &slot, m, link_handler, NULL, NULL, 0, NULL) >= 0);
-
-        assert_se(sd_netlink_slot_get_netlink(slot) == rtnl);
-        assert_se(!sd_netlink_slot_get_userdata(slot));
-        assert_se(!sd_netlink_slot_set_userdata(slot, ifname));
-        assert_se(sd_netlink_slot_get_userdata(slot) == ifname);
-        assert_se(sd_netlink_slot_get_destroy_callback(slot, NULL) == 0);
+        assert_se(sd_netlink_slot_set_destroy_callback(slot, NULL) >= 0);
+        assert_se(sd_netlink_slot_get_destroy_callback(slot, &destroy_callback) == 0);
+        assert_se(destroy_callback == NULL);
         assert_se(sd_netlink_slot_set_destroy_callback(slot, test_async_destroy) >= 0);
         assert_se(sd_netlink_slot_get_destroy_callback(slot, &destroy_callback) == 1);
         assert_se(destroy_callback == test_async_destroy);
+
         assert_se(sd_netlink_slot_get_floating(slot) == 0);
         assert_se(sd_netlink_slot_set_floating(slot, 1) == 1);
         assert_se(sd_netlink_slot_get_floating(slot) == 1);
-        assert_se(sd_netlink_slot_get_description(slot, NULL) == 0);
-        assert_se(sd_netlink_slot_set_description(slot, "hogehoge") >= 0);
+
         assert_se(sd_netlink_slot_get_description(slot, &description) == 1);
         assert_se(streq(description, "hogehoge"));
+        assert_se(sd_netlink_slot_set_description(slot, NULL) >= 0);
+        assert_se(sd_netlink_slot_get_description(slot, &description) == 0);
+        assert_se(description == NULL);
 
         assert_se(sd_netlink_wait(rtnl, 0) >= 0);
-        assert_se(sd_netlink_process(rtnl, &r) >= 0);
+        assert_se(sd_netlink_process(rtnl, &reply) >= 0);
 
         assert_se((rtnl = sd_netlink_unref(rtnl)) == NULL);
 }
@@ -322,23 +264,21 @@ static void test_async_object_destroy(void *userdata) {
         test_async_object_unref(t);
 }
 
-static void test_async_destroy_callback(int ifindex) {
+TEST(async_destroy_callback) {
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
-        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL, *r = NULL;
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL, *reply = NULL;
         _cleanup_(test_async_object_unrefp) struct test_async_object *t = NULL;
         _cleanup_(sd_netlink_slot_unrefp) sd_netlink_slot *slot = NULL;
-        char *ifname;
-
-        log_debug("/* %s */", __func__);
-
-        assert_se(t = new(struct test_async_object, 1));
-        assert_se(ifname = strdup("lo"));
-        *t = (struct test_async_object) {
-                .n_ref = 1,
-                .ifname = ifname,
-        };
+        int ifindex;
 
         assert_se(sd_netlink_open(&rtnl) >= 0);
+        ifindex = (int) if_nametoindex("lo");
+
+        assert_se(t = new(struct test_async_object, 1));
+        *t = (struct test_async_object) {
+                .n_ref = 1,
+        };
+        assert_se(t->ifname = strdup("lo"));
 
         /* destroy callback is called after processing message */
         assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_GETLINK, ifindex) >= 0);
@@ -349,7 +289,7 @@ static void test_async_destroy_callback(int ifindex) {
         assert_se(t->n_ref == 2);
 
         assert_se(sd_netlink_wait(rtnl, 0) >= 0);
-        assert_se(sd_netlink_process(rtnl, &r) == 1);
+        assert_se(sd_netlink_process(rtnl, &reply) == 1);
         assert_se(t->n_ref == 1);
 
         assert_se(!sd_netlink_message_unref(m));
@@ -394,14 +334,13 @@ static int pipe_handler(sd_netlink *rtnl, sd_netlink_message *m, void *userdata)
         return 1;
 }
 
-static void test_pipe(int ifindex) {
+TEST(pipe) {
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m1 = NULL, *m2 = NULL;
-        int counter = 0;
-
-        log_debug("/* %s */", __func__);
+        int ifindex, counter = 0;
 
         assert_se(sd_netlink_open(&rtnl) >= 0);
+        ifindex = (int) if_nametoindex("lo");
 
         assert_se(sd_rtnl_message_new_link(rtnl, &m1, RTM_GETLINK, ifindex) >= 0);
         assert_se(sd_rtnl_message_new_link(rtnl, &m2, RTM_GETLINK, ifindex) >= 0);
@@ -420,13 +359,14 @@ static void test_pipe(int ifindex) {
         assert_se((rtnl = sd_netlink_unref(rtnl)) == NULL);
 }
 
-static void test_container(sd_netlink *rtnl) {
+TEST(message_container) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         uint16_t u16_data;
         uint32_t u32_data;
         const char *string_data;
 
-        log_debug("/* %s */", __func__);
+        assert_se(sd_netlink_open(&rtnl) >= 0);
 
         assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_NEWLINK, 0) >= 0);
 
@@ -434,9 +374,7 @@ static void test_container(sd_netlink *rtnl) {
         assert_se(sd_netlink_message_open_container_union(m, IFLA_INFO_DATA, "vlan") >= 0);
         assert_se(sd_netlink_message_append_u16(m, IFLA_VLAN_ID, 100) >= 0);
         assert_se(sd_netlink_message_close_container(m) >= 0);
-        assert_se(sd_netlink_message_append_string(m, IFLA_INFO_KIND, "vlan") >= 0);
         assert_se(sd_netlink_message_close_container(m) >= 0);
-        assert_se(sd_netlink_message_close_container(m) == -EINVAL);
 
         assert_se(sd_netlink_message_rewind(m, rtnl) >= 0);
 
@@ -453,15 +391,11 @@ static void test_container(sd_netlink *rtnl) {
         assert_se(sd_netlink_message_exit_container(m) >= 0);
 
         assert_se(sd_netlink_message_read_u32(m, IFLA_LINKINFO, &u32_data) < 0);
-
-        assert_se(sd_netlink_message_exit_container(m) == -EINVAL);
 }
 
-static void test_match(void) {
+TEST(sd_netlink_add_match) {
         _cleanup_(sd_netlink_slot_unrefp) sd_netlink_slot *s1 = NULL, *s2 = NULL;
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
-
-        log_debug("/* %s */", __func__);
 
         assert_se(sd_netlink_open(&rtnl) >= 0);
 
@@ -475,17 +409,17 @@ static void test_match(void) {
         assert_se((rtnl = sd_netlink_unref(rtnl)) == NULL);
 }
 
-static void test_get_addresses(sd_netlink *rtnl) {
+TEST(dump_addresses) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL, *reply = NULL;
-        sd_netlink_message *m;
 
-        log_debug("/* %s */", __func__);
+        assert_se(sd_netlink_open(&rtnl) >= 0);
 
         assert_se(sd_rtnl_message_new_addr(rtnl, &req, RTM_GETADDR, 0, AF_UNSPEC) >= 0);
         assert_se(sd_netlink_message_set_request_dump(req, true) >= 0);
         assert_se(sd_netlink_call(rtnl, req, 0, &reply) >= 0);
 
-        for (m = reply; m; m = sd_netlink_message_next(m)) {
+        for (sd_netlink_message *m = reply; m; m = sd_netlink_message_next(m)) {
                 uint16_t type;
                 unsigned char scope, flags;
                 int family, ifindex;
@@ -505,20 +439,19 @@ static void test_get_addresses(sd_netlink *rtnl) {
         }
 }
 
-static void test_message(sd_netlink *rtnl) {
+TEST(sd_netlink_message_get_errno) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
 
-        log_debug("/* %s */", __func__);
+        assert_se(sd_netlink_open(&rtnl) >= 0);
 
         assert_se(message_new_synthetic_error(rtnl, -ETIMEDOUT, 1, &m) >= 0);
         assert_se(sd_netlink_message_get_errno(m) == -ETIMEDOUT);
 }
 
-static void test_array(void) {
+TEST(message_array) {
         _cleanup_(sd_netlink_unrefp) sd_netlink *genl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
-
-        log_debug("/* %s */", __func__);
 
         assert_se(sd_genl_socket_open(&genl) >= 0);
         assert_se(sd_genl_message_new(genl, CTRL_GENL_NAME, CTRL_CMD_GETFAMILY, &m) >= 0);
@@ -557,12 +490,13 @@ static void test_array(void) {
         assert_se(sd_netlink_message_exit_container(m) >= 0);
 }
 
-static void test_strv(sd_netlink *rtnl) {
+TEST(message_strv) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         _cleanup_strv_free_ char **names_in = NULL, **names_out;
         const char *p;
 
-        log_debug("/* %s */", __func__);
+        assert_se(sd_netlink_open(&rtnl) >= 0);
 
         assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_NEWLINKPROP, 1) >= 0);
 
@@ -624,15 +558,13 @@ static int genl_ctrl_match_callback(sd_netlink *genl, sd_netlink_message *m, voi
         return 0;
 }
 
-static void test_genl(void) {
+TEST(genl) {
         _cleanup_(sd_event_unrefp) sd_event *event = NULL;
         _cleanup_(sd_netlink_unrefp) sd_netlink *genl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         const char *name;
         uint8_t cmd;
         int r;
-
-        log_debug("/* %s */", __func__);
 
         assert_se(sd_genl_socket_open(&genl) >= 0);
         assert_se(sd_event_default(&event) >= 0);
@@ -669,14 +601,16 @@ static void test_genl(void) {
         }
 }
 
-static void test_rtnl_set_link_name(sd_netlink *rtnl, int ifindex) {
+TEST(rtnl_set_link_name) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_strv_free_ char **alternative_names = NULL;
-        int r;
-
-        log_debug("/* %s */", __func__);
+        int ifindex, r;
 
         if (geteuid() != 0)
                 return (void) log_tests_skipped("not root");
+
+        assert_se(sd_netlink_open(&rtnl) >= 0);
+        ifindex = (int) if_nametoindex("lo");
 
         /* Test that the new name (which is currently an alternative name) is
          * restored as an alternative name on error. Create an error by using
@@ -693,68 +627,4 @@ static void test_rtnl_set_link_name(sd_netlink *rtnl, int ifindex) {
         assert_se(rtnl_delete_link_alternative_names(&rtnl, ifindex, STRV_MAKE("testlongalternativename")) >= 0);
 }
 
-int main(void) {
-        sd_netlink *rtnl;
-        sd_netlink_message *m;
-        sd_netlink_message *r;
-        const char *string_data;
-        int if_loopback;
-        uint16_t type;
-
-        test_setup_logging(LOG_DEBUG);
-
-        test_match();
-        test_multiple();
-
-        assert_se(sd_netlink_open(&rtnl) >= 0);
-        assert_se(rtnl);
-
-        test_route(rtnl);
-        test_message(rtnl);
-        test_container(rtnl);
-        test_array();
-        test_strv(rtnl);
-
-        if_loopback = (int) if_nametoindex("lo");
-        assert_se(if_loopback > 0);
-
-        test_async(if_loopback);
-        test_slot_set(if_loopback);
-        test_async_destroy_callback(if_loopback);
-        test_pipe(if_loopback);
-        test_event_loop(if_loopback);
-        test_link_configure(rtnl, if_loopback);
-        test_rtnl_set_link_name(rtnl, if_loopback);
-
-        test_get_addresses(rtnl);
-        test_message_link_bridge(rtnl);
-
-        assert_se(sd_rtnl_message_new_link(rtnl, &m, RTM_GETLINK, if_loopback) >= 0);
-        assert_se(m);
-
-        assert_se(sd_netlink_message_get_type(m, &type) >= 0);
-        assert_se(type == RTM_GETLINK);
-
-        assert_se(sd_netlink_message_read_string(m, IFLA_IFNAME, &string_data) == -EPERM);
-
-        assert_se(sd_netlink_call(rtnl, m, 0, &r) == 1);
-        assert_se(sd_netlink_message_get_type(r, &type) >= 0);
-        assert_se(type == RTM_NEWLINK);
-
-        assert_se((r = sd_netlink_message_unref(r)) == NULL);
-
-        assert_se(sd_netlink_call(rtnl, m, -1, &r) == -EPERM);
-        assert_se((m = sd_netlink_message_unref(m)) == NULL);
-        assert_se((r = sd_netlink_message_unref(r)) == NULL);
-
-        test_link_get(rtnl, if_loopback);
-        test_address_get(rtnl, if_loopback);
-
-        assert_se((m = sd_netlink_message_unref(m)) == NULL);
-        assert_se((r = sd_netlink_message_unref(r)) == NULL);
-        assert_se((rtnl = sd_netlink_unref(rtnl)) == NULL);
-
-        test_genl();
-
-        return EXIT_SUCCESS;
-}
+DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/libsystemd/sd-netlink/test-netlink.c
+++ b/src/libsystemd/sd-netlink/test-netlink.c
@@ -601,30 +601,81 @@ TEST(genl) {
         }
 }
 
+static void remove_dummy_interfacep(int *ifindex) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL;
+
+        if (!ifindex || *ifindex <= 0)
+                return;
+
+        assert_se(sd_netlink_open(&rtnl) >= 0);
+
+        assert_se(sd_rtnl_message_new_link(rtnl, &message, RTM_DELLINK, *ifindex) >= 0);
+        assert_se(sd_netlink_call(rtnl, message, 0, NULL) == 1);
+}
+
 TEST(rtnl_set_link_name) {
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL, *reply = NULL;
+        _cleanup_(remove_dummy_interfacep) int ifindex = 0;
         _cleanup_strv_free_ char **alternative_names = NULL;
-        int ifindex, r;
+        int r;
 
         if (geteuid() != 0)
                 return (void) log_tests_skipped("not root");
 
         assert_se(sd_netlink_open(&rtnl) >= 0);
-        ifindex = (int) if_nametoindex("lo");
+
+        assert_se(sd_rtnl_message_new_link(rtnl, &message, RTM_NEWLINK, 0) >= 0);
+        assert_se(sd_netlink_message_append_string(message, IFLA_IFNAME, "test-netlink") >= 0);
+        assert_se(sd_netlink_message_open_container(message, IFLA_LINKINFO) >= 0);
+        assert_se(sd_netlink_message_append_string(message, IFLA_INFO_KIND, "dummy") >= 0);
+        r = sd_netlink_call(rtnl, message, 0, &reply);
+        if (r == -EPERM)
+                return (void) log_tests_skipped("missing required capabilities");
+        if (r == -EOPNOTSUPP)
+                return (void) log_tests_skipped("dummy network interface is not supported");
+        assert_se(r >= 0);
+
+        message = sd_netlink_message_unref(message);
+        reply = sd_netlink_message_unref(reply);
+
+        assert_se(sd_rtnl_message_new_link(rtnl, &message, RTM_GETLINK, 0) >= 0);
+        assert_se(sd_netlink_message_append_string(message, IFLA_IFNAME, "test-netlink") >= 0);
+        assert_se(sd_netlink_call(rtnl, message, 0, &reply) == 1);
+
+        assert_se(sd_rtnl_message_link_get_ifindex(reply, &ifindex) >= 0);
+        assert_se(ifindex > 0);
 
         /* Test that the new name (which is currently an alternative name) is
          * restored as an alternative name on error. Create an error by using
          * an invalid device name, namely one that exceeds IFNAMSIZ
          * (alternative names can exceed IFNAMSIZ, but not regular names). */
-        r = rtnl_set_link_alternative_names(&rtnl, ifindex, STRV_MAKE("testlongalternativename"));
+        r = rtnl_set_link_alternative_names(&rtnl, ifindex, STRV_MAKE("testlongalternativename", "test-shortname"));
         if (r == -EPERM)
                 return (void) log_tests_skipped("missing required capabilities");
-
+        if (r == -EOPNOTSUPP)
+                return (void) log_tests_skipped("alternative name is not supported");
         assert_se(r >= 0);
-        assert_se(rtnl_set_link_name(&rtnl, ifindex, "testlongalternativename") == -EINVAL);
+
         assert_se(rtnl_get_link_alternative_names(&rtnl, ifindex, &alternative_names) >= 0);
         assert_se(strv_contains(alternative_names, "testlongalternativename"));
+        assert_se(strv_contains(alternative_names, "test-shortname"));
+
+        assert_se(rtnl_set_link_name(&rtnl, ifindex, "testlongalternativename") == -EINVAL);
+        assert_se(rtnl_set_link_name(&rtnl, ifindex, "test-shortname") >= 0);
+
+        alternative_names = strv_free(alternative_names);
+        assert_se(rtnl_get_link_alternative_names(&rtnl, ifindex, &alternative_names) >= 0);
+        assert_se(strv_contains(alternative_names, "testlongalternativename"));
+        assert_se(!strv_contains(alternative_names, "test-shortname"));
+
         assert_se(rtnl_delete_link_alternative_names(&rtnl, ifindex, STRV_MAKE("testlongalternativename")) >= 0);
+
+        alternative_names = strv_free(alternative_names);
+        assert_se(rtnl_get_link_alternative_names(&rtnl, ifindex, &alternative_names) >= 0);
+        assert_se(!strv_contains(alternative_names, "testlongalternativename"));
+        assert_se(!strv_contains(alternative_names, "test-shortname"));
 }
 
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/libsystemd/sd-netlink/test-netlink.c
+++ b/src/libsystemd/sd-netlink/test-netlink.c
@@ -662,12 +662,13 @@ TEST(rtnl_set_link_name) {
         assert_se(strv_contains(alternative_names, "testlongalternativename"));
         assert_se(strv_contains(alternative_names, "test-shortname"));
 
-        assert_se(rtnl_set_link_name(&rtnl, ifindex, "testlongalternativename") == -EINVAL);
-        assert_se(rtnl_set_link_name(&rtnl, ifindex, "test-shortname") >= 0);
+        assert_se(rtnl_set_link_name(&rtnl, ifindex, "testlongalternativename", NULL) == -EINVAL);
+        assert_se(rtnl_set_link_name(&rtnl, ifindex, "test-shortname", STRV_MAKE("testlongalternativename", "test-shortname", "test-additional-name")) >= 0);
 
         alternative_names = strv_free(alternative_names);
         assert_se(rtnl_get_link_alternative_names(&rtnl, ifindex, &alternative_names) >= 0);
         assert_se(strv_contains(alternative_names, "testlongalternativename"));
+        assert_se(strv_contains(alternative_names, "test-additional-name"));
         assert_se(!strv_contains(alternative_names, "test-shortname"));
 
         assert_se(rtnl_delete_link_alternative_names(&rtnl, ifindex, STRV_MAKE("testlongalternativename")) >= 0);
@@ -675,6 +676,7 @@ TEST(rtnl_set_link_name) {
         alternative_names = strv_free(alternative_names);
         assert_se(rtnl_get_link_alternative_names(&rtnl, ifindex, &alternative_names) >= 0);
         assert_se(!strv_contains(alternative_names, "testlongalternativename"));
+        assert_se(strv_contains(alternative_names, "test-additional-name"));
         assert_se(!strv_contains(alternative_names, "test-shortname"));
 }
 

--- a/src/udev/net/link-config.c
+++ b/src/udev/net/link-config.c
@@ -841,8 +841,6 @@ static int link_apply_alternative_names(Link *link, sd_netlink **rtnl) {
                         }
                 }
 
-        if (link->new_name)
-                strv_remove(altnames, link->new_name);
         strv_remove(altnames, link->ifname);
 
         r = rtnl_get_link_alternative_names(rtnl, link->ifindex, &current_altnames);

--- a/src/udev/net/link-config.c
+++ b/src/udev/net/link-config.c
@@ -363,6 +363,7 @@ Link *link_free(Link *link) {
         sd_device_unref(link->device);
         free(link->kind);
         free(link->driver);
+        strv_free(link->altnames);
         return mfree(link);
 }
 
@@ -791,19 +792,22 @@ no_rename:
         return 0;
 }
 
-static int link_apply_alternative_names(Link *link, sd_netlink **rtnl) {
-        _cleanup_strv_free_ char **altnames = NULL, **current_altnames = NULL;
+static int link_generate_alternative_names(Link *link) {
+        _cleanup_strv_free_ char **altnames = NULL;
         LinkConfig *config;
         sd_device *device;
         int r;
 
         assert(link);
-        assert(link->config);
-        assert(link->device);
-        assert(rtnl);
+        config = ASSERT_PTR(link->config);
+        device = ASSERT_PTR(link->device);
+        assert(!link->altnames);
 
-        config = link->config;
-        device = link->device;
+        if (link->action != SD_DEVICE_ADD) {
+                log_link_debug(link, "Skipping to apply AlternativeNames= and AlternativeNamesPolicy= on '%s' uevent.",
+                               device_action_to_string(link->action));
+                return 0;
+        }
 
         if (config->alternative_names) {
                 altnames = strv_copy(config->alternative_names);
@@ -841,22 +845,7 @@ static int link_apply_alternative_names(Link *link, sd_netlink **rtnl) {
                         }
                 }
 
-        strv_remove(altnames, link->ifname);
-
-        r = rtnl_get_link_alternative_names(rtnl, link->ifindex, &current_altnames);
-        if (r < 0)
-                log_link_debug_errno(link, r, "Failed to get alternative names, ignoring: %m");
-
-        STRV_FOREACH(p, current_altnames)
-                strv_remove(altnames, *p);
-
-        strv_uniq(altnames);
-        strv_sort(altnames);
-        r = rtnl_set_link_alternative_names(rtnl, link->ifindex, altnames);
-        if (r < 0)
-                log_link_full_errno(link, r == -EOPNOTSUPP ? LOG_DEBUG : LOG_WARNING, r,
-                                    "Could not set AlternativeName= or apply AlternativeNamesPolicy=, ignoring: %m");
-
+        link->altnames = TAKE_PTR(altnames);
         return 0;
 }
 
@@ -958,7 +947,7 @@ int link_apply_config(LinkConfigContext *ctx, sd_netlink **rtnl, Link *link) {
         if (r < 0)
                 return r;
 
-        r = link_apply_alternative_names(link, rtnl);
+        r = link_generate_alternative_names(link);
         if (r < 0)
                 return r;
 

--- a/src/udev/net/link-config.c
+++ b/src/udev/net/link-config.c
@@ -834,7 +834,7 @@ static int link_apply_alternative_names(Link *link, sd_netlink **rtnl) {
                         default:
                                 assert_not_reached();
                         }
-                        if (!isempty(n)) {
+                        if (ifname_valid_full(n, IFNAME_VALID_ALTERNATIVE)) {
                                 r = strv_extend(&altnames, n);
                                 if (r < 0)
                                         return log_oom();

--- a/src/udev/net/link-config.c
+++ b/src/udev/net/link-config.c
@@ -722,7 +722,7 @@ static int link_generate_new_name(Link *link) {
         config = link->config;
         device = link->device;
 
-        if (link->action == SD_DEVICE_MOVE) {
+        if (link->action != SD_DEVICE_ADD) {
                 log_link_debug(link, "Skipping to apply Name= and NamePolicy= on '%s' uevent.",
                                device_action_to_string(link->action));
                 goto no_rename;

--- a/src/udev/net/link-config.h
+++ b/src/udev/net/link-config.h
@@ -27,6 +27,7 @@ typedef struct Link {
         int ifindex;
         const char *ifname;
         const char *new_name;
+        char **altnames;
 
         LinkConfig *config;
         sd_device *device;

--- a/src/udev/udev-builtin-blkid.c
+++ b/src/udev/udev-builtin-blkid.c
@@ -237,7 +237,8 @@ static int probe_superblocks(blkid_probe pr) {
         return blkid_do_safeprobe(pr);
 }
 
-static int builtin_blkid(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_blkid(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         const char *devnode, *root_partition = NULL, *data, *name;
         _cleanup_(blkid_free_probep) blkid_probe pr = NULL;
         bool noraid = false, is_gpt = false;

--- a/src/udev/udev-builtin-btrfs.c
+++ b/src/udev/udev-builtin-btrfs.c
@@ -13,7 +13,8 @@
 #include "udev-builtin.h"
 #include "util.h"
 
-static int builtin_btrfs(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_btrfs(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         struct btrfs_ioctl_vol_args args = {};
         _cleanup_close_ int fd = -1;
         int r;

--- a/src/udev/udev-builtin-hwdb.c
+++ b/src/udev/udev-builtin-hwdb.c
@@ -118,7 +118,7 @@ next:
         return r;
 }
 
-static int builtin_hwdb(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_hwdb(UdevEvent *event, int argc, char *argv[], bool test) {
         static const struct option options[] = {
                 { "filter", required_argument, NULL, 'f' },
                 { "device", required_argument, NULL, 'd' },
@@ -131,6 +131,7 @@ static int builtin_hwdb(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[
         const char *subsystem = NULL;
         const char *prefix = NULL;
         _cleanup_(sd_device_unrefp) sd_device *srcdev = NULL;
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         int r;
 
         if (!hwdb)

--- a/src/udev/udev-builtin-input_id.c
+++ b/src/udev/udev-builtin-input_id.c
@@ -356,8 +356,8 @@ static bool test_key(sd_device *dev,
         return found;
 }
 
-static int builtin_input_id(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
-        sd_device *pdev;
+static int builtin_input_id(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *pdev, *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         unsigned long bitmask_ev[NBITS(EV_MAX)];
         unsigned long bitmask_abs[NBITS(ABS_MAX)];
         unsigned long bitmask_key[NBITS(KEY_MAX)];
@@ -366,8 +366,6 @@ static int builtin_input_id(sd_device *dev, sd_netlink **rtnl, int argc, char *a
         const char *sysname;
         bool is_pointer;
         bool is_key;
-
-        assert(dev);
 
         /* walk up the parental chain until we find the real input device; the
          * argument is very likely a subdevice of this, like eventN */

--- a/src/udev/udev-builtin-keyboard.c
+++ b/src/udev/udev-builtin-keyboard.c
@@ -159,7 +159,8 @@ static int set_trackpoint_sensitivity(sd_device *dev, const char *value) {
         return 0;
 }
 
-static int builtin_keyboard(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_keyboard(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         unsigned release[1024];
         unsigned release_count = 0;
         _cleanup_close_ int fd = -1;

--- a/src/udev/udev-builtin-kmod.c
+++ b/src/udev/udev-builtin-kmod.c
@@ -22,10 +22,9 @@ _printf_(6,0) static void udev_kmod_log(void *data, int priority, const char *fi
         log_internalv(priority, 0, file, line, fn, format, args);
 }
 
-static int builtin_kmod(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_kmod(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         int r;
-
-        assert(dev);
 
         if (!ctx)
                 return 0;

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -1109,7 +1109,8 @@ static int get_link_info(sd_device *dev, LinkInfo *info) {
         return 0;
 }
 
-static int builtin_net_id(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_net_id(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         const char *prefix;
         NetNames names = {};
         LinkInfo info = {

--- a/src/udev/udev-builtin-net_setup_link.c
+++ b/src/udev/udev-builtin-net_setup_link.c
@@ -10,14 +10,15 @@
 
 static LinkConfigContext *ctx = NULL;
 
-static int builtin_net_setup_link(sd_device *dev, sd_netlink **rtnl, int argc, char **argv, bool test) {
+static int builtin_net_setup_link(UdevEvent *event, int argc, char **argv, bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         _cleanup_(link_freep) Link *link = NULL;
         int r;
 
         if (argc > 1)
                 return log_device_error_errno(dev, SYNTHETIC_ERRNO(EINVAL), "This program takes no arguments.");
 
-        r = link_new(ctx, rtnl, dev, &link);
+        r = link_new(ctx, &event->rtnl, dev, &link);
         if (r == -ENODEV) {
                 log_device_debug_errno(dev, r, "Link vanished while getting information, ignoring.");
                 return 0;
@@ -38,7 +39,7 @@ static int builtin_net_setup_link(sd_device *dev, sd_netlink **rtnl, int argc, c
                 return log_device_error_errno(dev, r, "Failed to get link config: %m");
         }
 
-        r = link_apply_config(ctx, rtnl, link);
+        r = link_apply_config(ctx, &event->rtnl, link);
         if (r == -ENODEV)
                 log_device_debug_errno(dev, r, "Link vanished while applying configuration, ignoring.");
         else if (r < 0)

--- a/src/udev/udev-builtin-net_setup_link.c
+++ b/src/udev/udev-builtin-net_setup_link.c
@@ -49,6 +49,8 @@ static int builtin_net_setup_link(UdevEvent *event, int argc, char **argv, bool 
         if (link->new_name)
                 udev_builtin_add_property(dev, test, "ID_NET_NAME", link->new_name);
 
+        event->altnames = TAKE_PTR(link->altnames);
+
         return 0;
 }
 

--- a/src/udev/udev-builtin-path_id.c
+++ b/src/udev/udev-builtin-path_id.c
@@ -581,14 +581,13 @@ static int find_real_nvme_parent(sd_device *dev, sd_device **ret) {
         return 0;
 }
 
-static int builtin_path_id(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_path_id(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         _cleanup_(sd_device_unrefp) sd_device *dev_other_branch = NULL;
         _cleanup_free_ char *path = NULL, *compat_path = NULL;
         bool supported_transport = false, supported_parent = false;
         const char *subsystem;
         int r;
-
-        assert(dev);
 
         /* walk up the chain of devices and compose path */
         for (sd_device *parent = dev; parent; ) {

--- a/src/udev/udev-builtin-uaccess.c
+++ b/src/udev/udev-builtin-uaccess.c
@@ -16,7 +16,8 @@
 #include "log.h"
 #include "udev-builtin.h"
 
-static int builtin_uaccess(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_uaccess(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         const char *path = NULL, *seat;
         bool changed_acl = false;
         uid_t uid;

--- a/src/udev/udev-builtin-usb_id.c
+++ b/src/udev/udev-builtin-usb_id.c
@@ -224,7 +224,8 @@ static int dev_if_packed_info(sd_device *dev, char *ifs_str, size_t len) {
  * 6.) If the device supplies a serial number, this number
  *     is concatenated with the identification with an underscore '_'.
  */
-static int builtin_usb_id(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test) {
+static int builtin_usb_id(UdevEvent *event, int argc, char *argv[], bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         char vendor_str[64] = "";
         char vendor_str_enc[256];
         const char *vendor_id;
@@ -249,8 +250,6 @@ static int builtin_usb_id(sd_device *dev, sd_netlink **rtnl, int argc, char *arg
 
         const char *syspath, *sysname, *devtype, *interface_syspath;
         int r;
-
-        assert(dev);
 
         r = sd_device_get_syspath(dev, &syspath);
         if (r < 0)

--- a/src/udev/udev-builtin.c
+++ b/src/udev/udev-builtin.c
@@ -98,11 +98,12 @@ UdevBuiltinCommand udev_builtin_lookup(const char *command) {
         return _UDEV_BUILTIN_INVALID;
 }
 
-int udev_builtin_run(sd_device *dev, sd_netlink **rtnl, UdevBuiltinCommand cmd, const char *command, bool test) {
+int udev_builtin_run(UdevEvent *event, UdevBuiltinCommand cmd, const char *command, bool test) {
         _cleanup_strv_free_ char **argv = NULL;
         int r;
 
-        assert(dev);
+        assert(event);
+        assert(event->dev);
         assert(cmd >= 0 && cmd < _UDEV_BUILTIN_MAX);
         assert(command);
 
@@ -115,7 +116,7 @@ int udev_builtin_run(sd_device *dev, sd_netlink **rtnl, UdevBuiltinCommand cmd, 
 
         /* we need '0' here to reset the internal state */
         optind = 0;
-        return builtins[cmd]->cmd(dev, rtnl, strv_length(argv), argv, test);
+        return builtins[cmd]->cmd(event, strv_length(argv), argv, test);
 }
 
 int udev_builtin_add_property(sd_device *dev, bool test, const char *key, const char *val) {

--- a/src/udev/udev-builtin.h
+++ b/src/udev/udev-builtin.h
@@ -6,6 +6,8 @@
 #include "sd-device.h"
 #include "sd-netlink.h"
 
+#include "udev-event.h"
+
 typedef enum UdevBuiltinCommand {
 #if HAVE_BLKID
         UDEV_BUILTIN_BLKID,
@@ -30,7 +32,7 @@ typedef enum UdevBuiltinCommand {
 
 typedef struct UdevBuiltin {
         const char *name;
-        int (*cmd)(sd_device *dev, sd_netlink **rtnl, int argc, char *argv[], bool test);
+        int (*cmd)(UdevEvent *event, int argc, char *argv[], bool test);
         const char *help;
         int (*init)(void);
         void (*exit)(void);
@@ -74,7 +76,7 @@ void udev_builtin_exit(void);
 UdevBuiltinCommand udev_builtin_lookup(const char *command);
 const char *udev_builtin_name(UdevBuiltinCommand cmd);
 bool udev_builtin_run_once(UdevBuiltinCommand cmd);
-int udev_builtin_run(sd_device *dev, sd_netlink **rtnl, UdevBuiltinCommand cmd, const char *command, bool test);
+int udev_builtin_run(UdevEvent *event, UdevBuiltinCommand cmd, const char *command, bool test);
 void udev_builtin_list(void);
 bool udev_builtin_should_reload(void);
 int udev_builtin_add_property(sd_device *dev, bool test, const char *key, const char *val);

--- a/src/udev/udev-event.c
+++ b/src/udev/udev-event.c
@@ -906,7 +906,8 @@ static int device_rename(sd_device *device, const char *name) {
 }
 
 static int rename_netif(UdevEvent *event) {
-        const char *oldname;
+        _cleanup_free_ char *old_syspath = NULL, *old_sysname = NULL;
+        const char *s;
         sd_device *dev;
         int ifindex, r;
 
@@ -917,15 +918,6 @@ static int rename_netif(UdevEvent *event) {
 
         dev = ASSERT_PTR(event->dev);
 
-        /* Read sysname from cloned sd-device object, otherwise use-after-free is triggered, as the
-         * main object will be renamed and dev->sysname will be freed in device_rename(). */
-        r = sd_device_get_sysname(event->dev_db_clone, &oldname);
-        if (r < 0)
-                return log_device_error_errno(dev, r, "Failed to get sysname: %m");
-
-        if (streq(event->name, oldname))
-                return 0; /* The interface name is already requested name. */
-
         if (!device_for_action(dev, SD_DEVICE_ADD))
                 return 0; /* Rename the interface only when it is added. */
 
@@ -933,7 +925,7 @@ static int rename_netif(UdevEvent *event) {
         if (r == -ENOENT)
                 return 0; /* Device is not a network interface. */
         if (r < 0)
-                return log_device_error_errno(dev, r, "Failed to get ifindex: %m");
+                return log_device_warning_errno(dev, r, "Failed to get ifindex: %m");
 
         if (naming_scheme_has(NAMING_REPLACE_STRICTLY) &&
             !ifname_valid(event->name)) {
@@ -941,39 +933,82 @@ static int rename_netif(UdevEvent *event) {
                 return 0;
         }
 
-        /* Set ID_RENAMING boolean property here. It will be dropped when the corresponding move uevent is processed. */
-        r = device_add_property(dev, "ID_RENAMING", "1");
+        r = sd_device_get_sysname(dev, &s);
         if (r < 0)
-                return log_device_warning_errno(dev, r, "Failed to add 'ID_RENAMING' property: %m");
+                return log_device_warning_errno(dev, r, "Failed to get sysname: %m");
+
+        if (streq(event->name, s))
+                return 0; /* The interface name is already requested name. */
+
+        old_sysname = strdup(s);
+        if (!old_sysname)
+                return -ENOMEM;
+
+        r = sd_device_get_syspath(dev, &s);
+        if (r < 0)
+                return log_device_warning_errno(dev, r, "Failed to get syspath: %m");
+
+        old_syspath = strdup(s);
+        if (!old_syspath)
+                return -ENOMEM;
 
         r = device_rename(dev, event->name);
-        if (r < 0)
-                return log_device_warning_errno(dev, r, "Failed to update properties with new name '%s': %m", event->name);
+        if (r < 0) {
+                log_device_warning_errno(dev, r, "Failed to update properties with new name '%s': %m", event->name);
+                goto revert;
+        }
+
+        /* Set ID_RENAMING boolean property here. It will be dropped when the corresponding move uevent is processed. */
+        r = device_add_property(dev, "ID_RENAMING", "1");
+        if (r < 0) {
+                log_device_warning_errno(dev, r, "Failed to add 'ID_RENAMING' property: %m");
+                goto revert;
+        }
 
         /* Also set ID_RENAMING boolean property to cloned sd_device object and save it to database
          * before calling rtnl_set_link_name(). Otherwise, clients (e.g., systemd-networkd) may receive
          * RTM_NEWLINK netlink message before the database is updated. */
         r = device_add_property(event->dev_db_clone, "ID_RENAMING", "1");
-        if (r < 0)
-                return log_device_warning_errno(event->dev_db_clone, r, "Failed to add 'ID_RENAMING' property: %m");
+        if (r < 0) {
+                log_device_warning_errno(event->dev_db_clone, r, "Failed to add 'ID_RENAMING' property: %m");
+                goto revert;
+        }
 
         r = device_update_db(event->dev_db_clone);
-        if (r < 0)
-                return log_device_debug_errno(event->dev_db_clone, r, "Failed to update database under /run/udev/data/: %m");
+        if (r < 0) {
+                log_device_debug_errno(event->dev_db_clone, r, "Failed to update database under /run/udev/data/: %m");
+                goto revert;
+        }
 
         r = rtnl_set_link_name(&event->rtnl, ifindex, event->name);
-        if (r == -EBUSY) {
-                log_device_info(dev, "Network interface '%s' is already up, cannot rename to '%s'.",
-                                oldname, event->name);
-                return 0;
+        if (r < 0) {
+                if (r == -EBUSY) {
+                        log_device_info(dev, "Network interface '%s' is already up, cannot rename to '%s'.",
+                                        old_sysname, event->name);
+                        r = 0;
+                } else
+                        log_device_error_errno(dev, r, "Failed to rename network interface %i from '%s' to '%s': %m",
+                                               ifindex, old_sysname, event->name);
+                goto revert;
         }
-        if (r < 0)
-                return log_device_error_errno(dev, r, "Failed to rename network interface %i from '%s' to '%s': %m",
-                                              ifindex, oldname, event->name);
 
-        log_device_debug(dev, "Network interface %i is renamed from '%s' to '%s'", ifindex, oldname, event->name);
-
+        log_device_debug(dev, "Network interface %i is renamed from '%s' to '%s'", ifindex, old_sysname, event->name);
         return 1;
+
+revert:
+        /* Restore 'dev_db_clone' */
+        (void) device_add_property(event->dev_db_clone, "ID_RENAMING", NULL);
+        (void) device_update_db(event->dev_db_clone);
+
+        /* Restore 'dev' */
+        (void) device_set_syspath(dev, old_syspath, /* verify = */ false);
+        if (sd_device_get_property_value(dev, "INTERFACE_OLD", &s) >= 0) {
+                (void) device_add_property_internal(dev, "INTERFACE", s);
+                (void) device_add_property_internal(dev, "INTERFACE_OLD", NULL);
+        }
+        (void) device_add_property(dev, "ID_RENAMING", NULL);
+
+        return r;
 }
 
 static int update_devnode(UdevEvent *event) {

--- a/src/udev/udev-event.c
+++ b/src/udev/udev-event.c
@@ -119,24 +119,24 @@ struct subst_map_entry {
 };
 
 static const struct subst_map_entry map[] = {
-           { .name = "devnode",  .fmt = 'N', .type = FORMAT_SUBST_DEVNODE },
-           { .name = "tempnode", .fmt = 'N', .type = FORMAT_SUBST_DEVNODE }, /* deprecated */
-           { .name = "attr",     .fmt = 's', .type = FORMAT_SUBST_ATTR },
-           { .name = "sysfs",    .fmt = 's', .type = FORMAT_SUBST_ATTR }, /* deprecated */
-           { .name = "env",      .fmt = 'E', .type = FORMAT_SUBST_ENV },
-           { .name = "kernel",   .fmt = 'k', .type = FORMAT_SUBST_KERNEL },
+           { .name = "devnode",  .fmt = 'N', .type = FORMAT_SUBST_DEVNODE       },
+           { .name = "tempnode", .fmt = 'N', .type = FORMAT_SUBST_DEVNODE       }, /* deprecated */
+           { .name = "attr",     .fmt = 's', .type = FORMAT_SUBST_ATTR          },
+           { .name = "sysfs",    .fmt = 's', .type = FORMAT_SUBST_ATTR          }, /* deprecated */
+           { .name = "env",      .fmt = 'E', .type = FORMAT_SUBST_ENV           },
+           { .name = "kernel",   .fmt = 'k', .type = FORMAT_SUBST_KERNEL        },
            { .name = "number",   .fmt = 'n', .type = FORMAT_SUBST_KERNEL_NUMBER },
-           { .name = "driver",   .fmt = 'd', .type = FORMAT_SUBST_DRIVER },
-           { .name = "devpath",  .fmt = 'p', .type = FORMAT_SUBST_DEVPATH },
-           { .name = "id",       .fmt = 'b', .type = FORMAT_SUBST_ID },
-           { .name = "major",    .fmt = 'M', .type = FORMAT_SUBST_MAJOR },
-           { .name = "minor",    .fmt = 'm', .type = FORMAT_SUBST_MINOR },
-           { .name = "result",   .fmt = 'c', .type = FORMAT_SUBST_RESULT },
-           { .name = "parent",   .fmt = 'P', .type = FORMAT_SUBST_PARENT },
-           { .name = "name",     .fmt = 'D', .type = FORMAT_SUBST_NAME },
-           { .name = "links",    .fmt = 'L', .type = FORMAT_SUBST_LINKS },
-           { .name = "root",     .fmt = 'r', .type = FORMAT_SUBST_ROOT },
-           { .name = "sys",      .fmt = 'S', .type = FORMAT_SUBST_SYS },
+           { .name = "driver",   .fmt = 'd', .type = FORMAT_SUBST_DRIVER        },
+           { .name = "devpath",  .fmt = 'p', .type = FORMAT_SUBST_DEVPATH       },
+           { .name = "id",       .fmt = 'b', .type = FORMAT_SUBST_ID            },
+           { .name = "major",    .fmt = 'M', .type = FORMAT_SUBST_MAJOR         },
+           { .name = "minor",    .fmt = 'm', .type = FORMAT_SUBST_MINOR         },
+           { .name = "result",   .fmt = 'c', .type = FORMAT_SUBST_RESULT        },
+           { .name = "parent",   .fmt = 'P', .type = FORMAT_SUBST_PARENT        },
+           { .name = "name",     .fmt = 'D', .type = FORMAT_SUBST_NAME          },
+           { .name = "links",    .fmt = 'L', .type = FORMAT_SUBST_LINKS         },
+           { .name = "root",     .fmt = 'r', .type = FORMAT_SUBST_ROOT          },
+           { .name = "sys",      .fmt = 'S', .type = FORMAT_SUBST_SYS           },
 };
 
 static const char *format_type_to_string(FormatSubstitutionType t) {

--- a/src/udev/udev-event.c
+++ b/src/udev/udev-event.c
@@ -862,7 +862,6 @@ int udev_event_spawn(
 static int rename_netif(UdevEvent *event) {
         const char *oldname;
         sd_device *dev;
-        unsigned flags;
         int ifindex, r;
 
         assert(event);
@@ -896,17 +895,7 @@ static int rename_netif(UdevEvent *event) {
                 return 0;
         }
 
-        r = rtnl_get_link_info(&event->rtnl, ifindex, NULL, &flags, NULL, NULL, NULL);
-        if (r < 0)
-                return log_device_warning_errno(dev, r, "Failed to get link flags: %m");
-
-        if (FLAGS_SET(flags, IFF_UP)) {
-                log_device_info(dev, "Network interface '%s' is already up, refusing to rename to '%s'.",
-                                oldname, event->name);
-                return 0;
-        }
-
-        /* Set ID_RENAMING boolean property here, and drop it in the corresponding move uevent later. */
+        /* Set ID_RENAMING boolean property here. It will be dropped when the corresponding move uevent is processed. */
         r = device_add_property(dev, "ID_RENAMING", "1");
         if (r < 0)
                 return log_device_warning_errno(dev, r, "Failed to add 'ID_RENAMING' property: %m");
@@ -927,6 +916,11 @@ static int rename_netif(UdevEvent *event) {
                 return log_device_debug_errno(event->dev_db_clone, r, "Failed to update database under /run/udev/data/: %m");
 
         r = rtnl_set_link_name(&event->rtnl, ifindex, event->name);
+        if (r == -EBUSY) {
+                log_device_info(dev, "Network interface '%s' is already up, cannot rename to '%s'.",
+                                oldname, event->name);
+                return 0;
+        }
         if (r < 0)
                 return log_device_error_errno(dev, r, "Failed to rename network interface %i from '%s' to '%s': %m",
                                               ifindex, oldname, event->name);

--- a/src/udev/udev-event.c
+++ b/src/udev/udev-event.c
@@ -1200,7 +1200,7 @@ void udev_event_execute_run(UdevEvent *event, usec_t timeout_usec, int timeout_s
 
                 if (builtin_cmd != _UDEV_BUILTIN_INVALID) {
                         log_device_debug(event->dev, "Running built-in command \"%s\"", command);
-                        r = udev_builtin_run(event->dev, &event->rtnl, builtin_cmd, command, false);
+                        r = udev_builtin_run(event, builtin_cmd, command, false);
                         if (r < 0)
                                 log_device_debug_errno(event->dev, r, "Failed to run built-in command \"%s\", ignoring: %m", command);
                 } else {

--- a/src/udev/udev-event.c
+++ b/src/udev/udev-event.c
@@ -980,7 +980,7 @@ static int rename_netif(UdevEvent *event) {
                 goto revert;
         }
 
-        r = rtnl_set_link_name(&event->rtnl, ifindex, event->name);
+        r = rtnl_set_link_name(&event->rtnl, ifindex, event->name, NULL);
         if (r < 0) {
                 if (r == -EBUSY) {
                         log_device_info(dev, "Network interface '%s' is already up, cannot rename to '%s'.",

--- a/src/udev/udev-event.c
+++ b/src/udev/udev-event.c
@@ -88,6 +88,7 @@ UdevEvent *udev_event_free(UdevEvent *event) {
         ordered_hashmap_free_free_free(event->seclabel_list);
         free(event->program_result);
         free(event->name);
+        strv_free(event->altnames);
 
         return mfree(event);
 }
@@ -918,9 +919,6 @@ static int rename_netif(UdevEvent *event) {
 
         dev = ASSERT_PTR(event->dev);
 
-        if (!device_for_action(dev, SD_DEVICE_ADD))
-                return 0; /* Rename the interface only when it is added. */
-
         r = sd_device_get_ifindex(dev, &ifindex);
         if (r == -ENOENT)
                 return 0; /* Device is not a network interface. */
@@ -980,7 +978,7 @@ static int rename_netif(UdevEvent *event) {
                 goto revert;
         }
 
-        r = rtnl_set_link_name(&event->rtnl, ifindex, event->name, NULL);
+        r = rtnl_set_link_name(&event->rtnl, ifindex, event->name, event->altnames);
         if (r < 0) {
                 if (r == -EBUSY) {
                         log_device_info(dev, "Network interface '%s' is already up, cannot rename to '%s'.",
@@ -1009,6 +1007,35 @@ revert:
         (void) device_add_property(dev, "ID_RENAMING", NULL);
 
         return r;
+}
+
+static int assign_altnames(UdevEvent *event) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
+        int ifindex, r;
+        const char *s;
+
+        if (strv_isempty(event->altnames))
+                return 0;
+
+        r = sd_device_get_ifindex(dev, &ifindex);
+        if (r == -ENOENT)
+                return 0; /* Device is not a network interface. */
+        if (r < 0)
+                return log_device_warning_errno(dev, r, "Failed to get ifindex: %m");
+
+        r = sd_device_get_sysname(dev, &s);
+        if (r < 0)
+                return log_device_warning_errno(dev, r, "Failed to get sysname: %m");
+
+        /* Filter out the current interface name. */
+        strv_remove(event->altnames, s);
+
+        r = rtnl_append_link_alternative_names(&event->rtnl, ifindex, event->altnames);
+        if (r < 0)
+                log_device_full_errno(dev, r == -EOPNOTSUPP ? LOG_DEBUG : LOG_WARNING, r,
+                                      "Could not set AlternativeName= or apply AlternativeNamesPolicy=, ignoring: %m");
+
+        return 0;
 }
 
 static int update_devnode(UdevEvent *event) {
@@ -1163,9 +1190,13 @@ int udev_event_execute_rules(
 
         DEVICE_TRACE_POINT(rules_finished, dev);
 
-        r = rename_netif(event);
-        if (r < 0)
-                return r;
+        if (action == SD_DEVICE_ADD) {
+                r = rename_netif(event);
+                if (r < 0)
+                        return r;
+                if (r == 0)
+                        (void) assign_altnames(event);
+        }
 
         r = update_devnode(event);
         if (r < 0)

--- a/src/udev/udev-event.h
+++ b/src/udev/udev-event.h
@@ -23,6 +23,7 @@ typedef struct UdevEvent {
         sd_device *dev_parent;
         sd_device *dev_db_clone;
         char *name;
+        char **altnames;
         char *program_result;
         mode_t mode;
         uid_t uid;

--- a/src/udev/udev-rules.c
+++ b/src/udev/udev-rules.c
@@ -1972,7 +1972,7 @@ static int udev_rule_apply_token_to_event(
 
                 log_rule_debug(dev, rules, "Importing properties from results of builtin command '%s'", buf);
 
-                r = udev_builtin_run(dev, &event->rtnl, cmd, buf, false);
+                r = udev_builtin_run(event, cmd, buf, false);
                 if (r < 0) {
                         /* remember failure */
                         log_rule_debug_errno(dev, rules, r, "Failed to run builtin '%s': %m", buf);

--- a/src/udev/udevadm-test-builtin.c
+++ b/src/udev/udevadm-test-builtin.c
@@ -87,8 +87,7 @@ int builtin_main(int argc, char *argv[], void *userdata) {
 
         cmd = udev_builtin_lookup(arg_command);
         if (cmd < 0) {
-                log_error("Unknown command '%s'", arg_command);
-                r = -EINVAL;
+                r = log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Unknown command '%s'", arg_command);
                 goto finish;
         }
 

--- a/src/udev/udevadm-test-builtin.c
+++ b/src/udev/udevadm-test-builtin.c
@@ -72,7 +72,7 @@ static int parse_argv(int argc, char *argv[]) {
 }
 
 int builtin_main(int argc, char *argv[], void *userdata) {
-        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
+        _cleanup_(udev_event_freep) UdevEvent *event = NULL;
         _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
         UdevBuiltinCommand cmd;
         int r;
@@ -97,7 +97,13 @@ int builtin_main(int argc, char *argv[], void *userdata) {
                 goto finish;
         }
 
-        r = udev_builtin_run(dev, &rtnl, cmd, arg_command, true);
+        event = udev_event_new(dev, 0, NULL, LOG_DEBUG);
+        if (!event) {
+                r = log_oom();
+                goto finish;
+        }
+
+        r = udev_builtin_run(event, cmd, arg_command, true);
         if (r < 0)
                 log_debug_errno(r, "Builtin command '%s' fails: %m", arg_command);
 

--- a/test/test-network/conf/12-dummy-rename-to-altname.link
+++ b/test/test-network/conf/12-dummy-rename-to-altname.link
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Match]
+OriginalName=dummy98
+
+[Link]
+Name=dummyalt
+AlternativeName=dummyalt hogehogehogehogehogehoge

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -936,6 +936,17 @@ class NetworkctlTests(unittest.TestCase, Utilities):
         output = check_output(*networkctl_cmd, '-n', '0', 'status', 'dummy98', env=env)
         self.assertRegex(output, 'hogehogehogehogehogehoge')
 
+    @expectedFailureIfAlternativeNameIsNotAvailable()
+    def test_rename_to_altname(self):
+        copy_network_unit('26-netdev-link-local-addressing-yes.network',
+                          '12-dummy.netdev', '12-dummy-rename-to-altname.link')
+        start_networkd()
+        self.wait_online(['dummyalt:degraded'])
+
+        output = check_output(*networkctl_cmd, '-n', '0', 'status', 'dummyalt', env=env)
+        self.assertIn('hogehogehogehogehogehoge', output)
+        self.assertNotIn('dummy98', output)
+
     def test_reconfigure(self):
         copy_network_unit('25-address-static.network', '12-dummy.netdev')
         start_networkd()

--- a/test/units/testsuite-17.02.sh
+++ b/test/units/testsuite-17.02.sh
@@ -102,4 +102,82 @@ timeout 30 bash -c 'while [[ "$(systemctl show --property=ActiveState --value /s
 # cleanup
 ip link del hoge
 
+teardown_netif_renaming_conflict() {
+    set +ex
+
+    if [[ -n "$KILL_PID" ]]; then
+        kill "$KILL_PID"
+    fi
+
+    rm -rf "$TMPDIR"
+
+    rm -f /run/udev/rules.d/50-testsuite.rules
+    udevadm control --reload --timeout=30
+
+    ip link del hoge
+    ip link del foobar
+}
+
+test_netif_renaming_conflict() {
+    local since found=
+
+    trap teardown_netif_renaming_conflict RETURN
+
+    cat >/run/udev/rules.d/50-testsuite.rules <<EOF
+ACTION!="add", GOTO="hoge_end"
+SUBSYSTEM!="net", GOTO="hoge_end"
+
+OPTIONS="log_level=debug"
+
+KERNEL=="foobar", NAME="hoge"
+
+LABEL="hoge_end"
+EOF
+
+    udevadm control --log-priority=debug --reload --timeout=30
+
+    ip link add hoge type dummy
+    udevadm wait --timeout=30 --settle /sys/devices/virtual/net/hoge
+
+    TMPDIR=$(mktemp -d -p /tmp udev-tests.XXXXXX)
+    udevadm monitor --udev --property --subsystem-match=net >"$TMPDIR"/monitor.txt &
+    KILL_PID="$!"
+
+    # make sure that 'udevadm monitor' actually monitor uevents
+    sleep 1
+
+    since="$(date '+%H:%M:%S')"
+
+    # add another interface which will conflict with an existing interface
+    ip link add foobar type dummy
+
+    for _ in {1..40}; do
+        if (
+            grep -q 'ACTION=add' "$TMPDIR"/monitor.txt
+            grep -q 'DEVPATH=/devices/virtual/net/foobar' "$TMPDIR"/monitor.txt
+            grep -q 'SUBSYSTEM=net' "$TMPDIR"/monitor.txt
+            grep -q 'INTERFACE=foobar' "$TMPDIR"/monitor.txt
+            grep -q 'ID_NET_DRIVER=dummy' "$TMPDIR"/monitor.txt
+            grep -q 'ID_NET_NAME=foobar' "$TMPDIR"/monitor.txt
+            # Even when network interface renaming is failed, SYSTEMD_ALIAS with the conflicting name will be broadcast.
+            grep -q 'SYSTEMD_ALIAS=/sys/subsystem/net/devices/hoge' "$TMPDIR"/monitor.txt
+            grep -q 'UDEV_WORKER_FAILED=1' "$TMPDIR"/monitor.txt
+            grep -q 'UDEV_WORKER_ERRNO=17' "$TMPDIR"/monitor.txt
+            grep -q 'UDEV_WORKER_ERRNO_NAME=EEXIST' "$TMPDIR"/monitor.txt
+        ); then
+            cat "$TMPDIR"/monitor.txt
+            found=1
+            break
+        fi
+        sleep .5
+    done
+    test -n "$found"
+
+    timeout 30 bash -c "while ! journalctl _PID=1 _COMM=systemd --since $since | grep -q 'foobar: systemd-udevd failed to process the device, ignoring: File exists'; do sleep 1; done"
+    # check if the invalid SYSTEMD_ALIAS property for the interface foobar is ignored by PID1
+    assert_eq "$(systemctl show --property=SysFSPath --value /sys/subsystem/net/devices/hoge)" "/sys/devices/virtual/net/hoge"
+}
+
+test_netif_renaming_conflict
+
 exit 0

--- a/test/units/testsuite-17.12.sh
+++ b/test/units/testsuite-17.12.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -ex
+set -o pipefail
+
+# shellcheck source=test/units/assert.sh
+. "$(dirname "$0")"/assert.sh
+
+create_link_file() {
+    name=${1?}
+
+    mkdir -p /run/systemd/network/
+    cat >/run/systemd/network/10-test.link <<EOF
+[Match]
+Kind=dummy
+MACAddress=00:50:56:c0:00:18
+
+[Link]
+Name=$name
+AlternativeName=test1 test2 test3 test4
+EOF
+    udevadm control --reload
+}
+
+udevadm control --log-level=debug
+
+create_link_file test1
+ip link add address 00:50:56:c0:00:18 type dummy
+udevadm wait --settle --timeout=30 /sys/class/net/test1
+output=$(ip link show dev test1)
+if ! [[ "$output" =~ altname ]]; then
+    echo "alternative name for network interface not supported, skipping test."
+    exit 0
+fi
+assert_not_in "altname test1" "$output"
+assert_in "altname test2" "$output"
+assert_in "altname test3" "$output"
+assert_in "altname test4" "$output"
+
+# By triggering add event, Name= and AlternativeNames= are re-applied
+create_link_file test2
+udevadm trigger --action add --settle /sys/class/net/test1
+udevadm wait --settle --timeout=30 /sys/class/net/test2
+output=$(ip link show dev test2)
+assert_in "altname test1" "$output"
+assert_not_in "altname test2" "$output"
+assert_in "altname test3" "$output"
+assert_in "altname test4" "$output"
+
+# Name= and AlternativeNames= are not applied on move event
+create_link_file test3
+udevadm trigger --action move --settle /sys/class/net/test2
+udevadm wait --settle --timeout=30 /sys/class/net/test2
+output=$(ip link show dev test2)
+assert_in "altname test1" "$output"
+assert_not_in "altname test2" "$output"
+assert_in "altname test3" "$output"
+assert_in "altname test4" "$output"
+
+# Test move event triggered by manual renaming
+ip link set dev test2 name hoge
+udevadm wait --settle --timeout=30 /sys/class/net/hoge
+output=$(ip link show dev hoge)
+assert_in "altname test1" "$output"
+assert_not_in "altname test2" "$output"
+assert_in "altname test3" "$output"
+assert_in "altname test4" "$output"
+assert_not_in "altname hoge" "$output"
+
+# Re-test add event
+udevadm trigger --action add --settle /sys/class/net/hoge
+udevadm wait --settle --timeout=30 /sys/class/net/test3
+output=$(ip link show dev test3)
+assert_in "altname test1" "$output"
+assert_in "altname test2" "$output"
+assert_not_in "altname test3" "$output"
+assert_in "altname test4" "$output"
+assert_not_in "altname hoge" "$output"
+
+# cleanup
+ip link del dev test3
+
+rm -f /run/systemd/network/10-test.link
+udevadm control --reload --log-level=info
+
+exit 0


### PR DESCRIPTION


<!-- advanced-commit-linter = {"comment-id":"1669477563"} -->