### PR TITLE
(#2231845) udev/net_id: use naming scheme for RHEL-9.3

### DIFF
--- a/src/shared/netif-naming-scheme.c
+++ b/src/shared/netif-naming-scheme.c
@@ -28,6 +28,7 @@ static const NamingScheme naming_schemes[] = {
         { "rhel-9.0", NAMING_RHEL_9_0 },
         { "rhel-9.1", NAMING_RHEL_9_1 },
         { "rhel-9.2", NAMING_RHEL_9_2 },
+        { "rhel-9.3", NAMING_RHEL_9_3 },
         /* … add more schemes here, as the logic to name devices is updated … */
 
         EXTRA_NET_NAMING_MAP


### PR DESCRIPTION
rhel-only

Resolves: #2231845

https://github.com/redhat-plumbers/systemd-rhel9/blob/eff259c8c7677bbbe64890873bd64349871dd6c5/man/systemd.net-naming-scheme.xml#L486-L495

https://github.com/redhat-plumbers/systemd-rhel9/blob/eff259c8c7677bbbe64890873bd64349871dd6c5/src/shared/netif-naming-scheme.h#L58


<!-- advanced-commit-linter = {"comment-id":"1677352515"} -->