### PR TITLE
(#2239576) rules: online CPU automatically on IBM s390x platforms when configured

### DIFF
--- a/rules.d/40-redhat.rules
+++ b/rules.d/40-redhat.rules
@@ -3,7 +3,8 @@
 # CPU hotadd request
 SUBSYSTEM!="cpu", GOTO="cpu_online_end"
 ACTION!="add", GOTO="cpu_online_end"
-CONST{arch}=="s390*|ppc64*", GOTO="cpu_online_end"
+CONST{arch}=="ppc64*", GOTO="cpu_online_end"
+CONST{arch}=="s390*", ATTR{configure}=="0", GOTO="cpu_online_end"
 
 TEST=="online", ATTR{online}=="0", ATTR{online}="1"
 


### PR DESCRIPTION
RHEL-only

Fix CPU hotplug regression on s390x introduced by commit 94c7e260b499 ("rules: do not online CPU automatically on IBM platforms"). After discussion with IBM, CPUs should be auto-enabled when in the configured state after a hotplug. However, if the CPU is deconfigured, it should not.

This is because on zVM and KVM hotplugged CPUs are configured and on LPAR/DPM they are deconfigured.

Resolves: #2239576
Signed-off-by: Cédric Le Goater <clg@redhat.com>

(cherry picked from commit 65d993c2efe52d683396dc3181cc79f29698bf39)

<!-- advanced-commit-linter = {"comment-id":"1741302723"} -->