### PR TITLE
(RHEL-11040) udev: raise RLIMIT_NOFILE as high as we can

### DIFF
--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -55,6 +55,7 @@
 #include "pretty-print.h"
 #include "proc-cmdline.h"
 #include "process-util.h"
+#include "rlimit-util.h"
 #include "selinux-util.h"
 #include "signal-util.h"
 #include "socket-util.h"
@@ -2039,6 +2040,9 @@ int run_udevd(int argc, char *argv[]) {
         r = mac_selinux_init();
         if (r < 0)
                 return r;
+
+        /* Make sure we can have plenty fds (for example for pidfds) */
+        (void) rlimit_nofile_bump(-1);
 
         r = RET_NERRNO(mkdir("/run/udev", 0755));
         if (r < 0 && r != -EEXIST)


### PR DESCRIPTION
We might need a lot of fds on large systems, hence raise RLIMIT_NOFILE to what the service manager allows us, which is quite a lot these days.

udev already sets FORK_RLIMIT_NOFILE_SAFE when forking of chilren, thus ensuring that forked off processes get their RLIMIT_NOFILE soft limit reset to 1K for compat with crappy old select().

Replaces: #29298
Fixes: #28583
(cherry picked from commit 1617424ce76d797d081dd6cb1082b954c4d2bf38)

Resolves: RHEL-11040

<!-- advanced-commit-linter = {"comment-id":"1780698140"} -->