### PR TITLE
(RHEL-1086) ci(lint): exclude `.in` files from ShellCheck lint

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -32,4 +32,6 @@ jobs:
       - name: Differential ShellCheck
         uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
+          # exclude all `.in` files because they may contain unsupported syntax, and they have to be preprocessed first
+          exclude-path: '**/*.in'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Exclude all `.in` files because they may contain unsupported syntax, and they have to be preprocessed first. For example:

```sh
Error: SHELLCHECK_WARNING:
./src/rpm/systemd-update-helper.in:130:37: warning[SC1083]: This { is literal. Check expression (missing ;/\n?) or quote it.
```

Related to: https://github.com/systemd/systemd/pull/28521

(cherry picked from commit 97eb82682126e7f3ee956a025078ea2b801955cb)

Related: RHEL-1086

<!-- advanced-commit-linter = {"comment-id":"1792373990"} -->