### PR TITLE
ci: add missing permissions

### DIFF
--- a/.github/workflows/source-git-automation-on-demand.yml
+++ b/.github/workflows/source-git-automation-on-demand.yml
@@ -63,6 +63,7 @@ jobs:
       contents: write
       statuses: write
       checks: write
+      issues: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/source-git-automation.yml
+++ b/.github/workflows/source-git-automation.yml
@@ -92,6 +92,7 @@ jobs:
     permissions:
       contents: write
       checks: write
+      issues: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
issues: write is required for the pull request merging according to:

https://github.com/cli/cli/discussions/6379#discussioncomment-3806051

rhel-only

Related: RHEL-1086