### PR TITLE
(RHEL-13199) meson: fix installation of ukify

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3868,9 +3868,9 @@ ukify = custom_target(
 if want_ukify
         public_programs += ukify
 
-        meson.add_install_script(sh, '-c',
-                                 ln_s.format(bindir / 'ukify',
-                                             rootlibexecdir / 'ukify'))
+        meson.add_install_script(meson_make_symlink,
+                                 bindir / 'ukify',
+                                 rootlibexecdir / 'ukify')
 endif
 
 if want_tests != 'false' and want_kernel_install


### PR DESCRIPTION
ln_s was added in upstream later on. It's not present in this branch. Fixup for b98da2d9e7.

Related: RHEL-13199

<!-- advanced-commit-linter = {"comment-id":"1847657306"} -->