### PR TITLE
(RHEL-19436) man: mention RHEL documentation in systemctl's man page

### DIFF
--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -2519,17 +2519,6 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
   </refsect1>
 
   <refsect1>
-    <title>Examples</title>
-    <para>
-            For examples how to use systemctl in comparsion
-            with old service and chkconfig command please see:
-            <ulink url="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_basic_system_settings/managing-system-services-with-systemctl_configuring-basic-system-settings">
-                    Managing System Services
-            </ulink>
-    </para>
-  </refsect1>
-
-  <refsect1>
     <title>See Also</title>
     <para>
       <citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry>,

--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -2519,6 +2519,16 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
   </refsect1>
 
   <refsect1>
+    <title>Examples</title>
+    <para>
+            For examples how to use systemctl in comparison with old service and chkconfig commands please see:
+            <ulink url="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_basic_system_settings/managing-systemd_configuring-basic-system-settings#managing-system-services-with-systemctl_managing-systemd">
+                    Managing System Services
+            </ulink>
+    </para>
+  </refsect1>
+
+  <refsect1>
     <title>See Also</title>
     <para>
       <citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry>,


### PR DESCRIPTION
The original link pointed to a non-existing page, so let's update it.

<!-- advanced-commit-linter = {"comment-id":"1855540505"} -->