### PR TITLE
(RHEL-1086) Automation improvements and issue fixes

### DIFF
--- a/.github/tracker-validator.yml
+++ b/.github/tracker-validator.yml
@@ -7,12 +7,22 @@ products:
   - Red Hat Enterprise Linux 9
   - CentOS Stream 9
   - rhel-9.0.0
+  - rhel-9.0.0.z
   - rhel-9.2.0
+  - rhel-9.2.0.z
   - rhel-9.3.0
+  - rhel-9.3.0.z
   - rhel-9.4.0
+  - rhel-9.4.0.z
   - rhel-9.5.0
+  - rhel-9.5.0.z
   - rhel-9.6.0
+  - rhel-9.6.0.z
   - rhel-9.7.0
+  - rhel-9.7.0.z
   - rhel-9.8.0
+  - rhel-9.8.0.z
   - rhel-9.9.0
+  - rhel-9.9.0.z
   - rhel-9.10.0
+  - rhel-9.10.0.z

--- a/.github/workflows/source-git-automation-on-demand.yml
+++ b/.github/workflows/source-git-automation-on-demand.yml
@@ -1,8 +1,8 @@
 name: Source git Automation Scheduled/On Demand
 on:
   schedule:
-    # Workflow runs every 15 minutes
-    - cron: '*/15 * * * *'
+    # Workflow runs every 45 minutes
+    - cron: '*/45 * * * *'
   workflow_dispatch:
     inputs:
       pr-number:

--- a/.github/workflows/source-git-automation-on-demand.yml
+++ b/.github/workflows/source-git-automation-on-demand.yml
@@ -1,5 +1,3 @@
----
-
 name: Source git Automation Scheduled/On Demand
 on:
   schedule:
@@ -59,62 +57,17 @@ jobs:
       matrix:
         pr-number: ${{ inputs.pr-number == 0 && fromJSON(needs.gather-pull-requests.outputs.pr-numbers) || fromJSON(needs.gather-pull-requests.outputs.pr-numbers-manual) }}
 
-    permissions: write-all
-      # contents: write
-      # statuses: write
-      # checks: write
-      # pull-requests: write
+    permissions:
+      # required for merging PRs
+      contents: write
+      # required for PR comments and setting labels
+      pull-requests: write
 
     steps:
-      - name: Repository checkout
-        uses: actions/checkout@v3
-
-      - id: metadata
-        name: Gather Pull Request Metadata
-        uses: redhat-plumbers-in-action/gather-pull-request-metadata@v1
+      - name: Source-git Automation
+        uses: redhat-plumbers-in-action/source-git-automation@v1
         with:
           pr-number: ${{ matrix.pr-number }}
-
-      - if: ${{ !cancelled() }}
-        id: commit-linter
-        name: Lint Commits
-        uses: redhat-plumbers-in-action/advanced-commit-linter@v2
-        with:
-          pr-metadata: ${{ steps.metadata.outputs.metadata }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Validates tracker, changes tracker status, updates PR title
-      - if: ${{ !cancelled() }}
-        id: tracker-validator
-        name: Validate Tracker
-        uses: redhat-plumbers-in-action/tracker-validator@v1
-        with:
-          pr-metadata: ${{ steps.metadata.outputs.metadata }}
-          component: systemd
-          tracker: ${{ fromJSON(steps.commit-linter.outputs.validated-pr-metadata).validation.tracker.id }}
-          tracker-type: ${{ fromJSON(steps.commit-linter.outputs.validated-pr-metadata).validation.tracker.type }}
-          bugzilla-instance: https://bugzilla.redhat.com
           bugzilla-api-token: ${{ secrets.BUGZILLA_API_TOKEN }}
-          jira-instance: https://issues.redhat.com
-          jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - if: ${{ !cancelled() }}
-        name: Pull Request Validator
-        uses: redhat-plumbers-in-action/pull-request-validator@v1
-        with:
-          pr-metadata: ${{ steps.metadata.outputs.metadata }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: auto-merge
-        name: Auto Merge
-        uses: redhat-plumbers-in-action/auto-merge@v1
-        with:
-          pr-metadata: ${{ steps.metadata.outputs.metadata }}
-          tracker: ${{ fromJSON(steps.commit-linter.outputs.validated-pr-metadata).validation.tracker.id }}
-          tracker-type: ${{ fromJSON(steps.commit-linter.outputs.validated-pr-metadata).validation.tracker.type }}
-          bugzilla-instance: https://bugzilla.redhat.com
-          bugzilla-api-token: ${{ secrets.BUGZILLA_API_TOKEN }}
-          jira-instance: https://issues.redhat.com
           jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/source-git-automation.yml
+++ b/.github/workflows/source-git-automation.yml
@@ -26,83 +26,21 @@ jobs:
         with:
           name: pr-metadata
 
-  commit-linter:
-    needs: [ download-metadata ]
-    runs-on: ubuntu-latest
-
-    outputs:
-      validated-pr-metadata: ${{ steps.commit-linter.outputs.validated-pr-metadata }}
-
-    permissions:
-      statuses: write
-      checks: write
-      pull-requests: write
-
-    steps:
-      - id: commit-linter
-        name: Lint Commits
-        uses: redhat-plumbers-in-action/advanced-commit-linter@v2
-        with:
-          pr-metadata: ${{ needs.download-metadata.outputs.pr-metadata }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  # Validates tracker, changes tracker status, updates PR title
-  tracker-validator:
-    if: ${{ !cancelled() }}
-    needs: [ download-metadata, commit-linter ]
-    runs-on: ubuntu-latest
-
-    permissions:
-      checks: write
-      pull-requests: write
-
-    steps:
-      - name: Validate Tracker
-        uses: redhat-plumbers-in-action/tracker-validator@v1
-        with:
-          pr-metadata: ${{ needs.download-metadata.outputs.pr-metadata }}
-          component: systemd
-          tracker: ${{ fromJSON(needs.commit-linter.outputs.validated-pr-metadata).validation.tracker.id }}
-          tracker-type: ${{ fromJSON(needs.commit-linter.outputs.validated-pr-metadata).validation.tracker.type }}
-          bugzilla-instance: https://bugzilla.redhat.com
-          bugzilla-api-token: ${{ secrets.BUGZILLA_API_TOKEN }}
-          jira-instance: https://issues.redhat.com
-          jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  pull-request-validator:
+  source-git-automation:
     needs: [ download-metadata ]
     runs-on: ubuntu-latest
 
     permissions:
-      checks: write
-      pull-requests: write
-
-    steps:
-      - name: Pull Request Validator
-        uses: redhat-plumbers-in-action/pull-request-validator@v1
-        with:
-          pr-metadata: ${{ needs.download-metadata.outputs.pr-metadata }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  auto-merge:
-    needs: [ download-metadata, commit-linter, tracker-validator, pull-request-validator ]
-    runs-on: ubuntu-latest
-
-    permissions:
+      # required for merging PRs
       contents: write
-      checks: write
+      # required for PR comments and setting labels
       pull-requests: write
 
     steps:
-      - name: Auto Merge
-        uses: redhat-plumbers-in-action/auto-merge@v1
+      - name: Source-git Automation
+        uses: redhat-plumbers-in-action/source-git-automation@v1
         with:
           pr-metadata: ${{ needs.download-metadata.outputs.pr-metadata }}
-          tracker: ${{ fromJSON(needs.commit-linter.outputs.validated-pr-metadata).validation.tracker.id }}
-          tracker-type: ${{ fromJSON(needs.commit-linter.outputs.validated-pr-metadata).validation.tracker.type }}
-          bugzilla-instance: https://bugzilla.redhat.com
           bugzilla-api-token: ${{ secrets.BUGZILLA_API_TOKEN }}
-          jira-instance: https://issues.redhat.com
           jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Increase the cron interval to 45 minutes
* Use composite GitHub Action to reduce maintenance cost
* Add Z-streams to an array of supported versions
* Don't fail CI when validation/linting fails; instead show everything in a sticky comment in the PR

#### Example of new status reporting in sticky comment

![Screenshot from 2024-01-12 15-38-28](https://github.com/redhat-plumbers/systemd-rhel9/assets/2879818/83c16b1d-0835-4c77-9df4-a92ee69b7e76)


<!-- advanced-commit-linter = {"comment-id":"1889392987"} -->