### PR TITLE
(RHEL-19483) core: mount namespaces: Remove auxiliary bind mounts directory after …

### DIFF
--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -5478,6 +5478,23 @@ int exec_context_destroy_credentials(const ExecContext *c, const char *runtime_p
         return 0;
 }
 
+int exec_context_destroy_mount_ns_dir(Unit *u) {
+        _cleanup_free_ char *p = NULL;
+
+        if (!u || !MANAGER_IS_SYSTEM(u->manager))
+                return 0;
+
+        p = path_join("/run/systemd/propagate/", u->id);
+        if (!p)
+                return -ENOMEM;
+
+        /* This is only filled transiently (see mount_in_namespace()), should be empty or even non-existent*/
+        if (rmdir(p) < 0 && errno != ENOENT)
+                log_unit_debug_errno(u, errno, "Unable to remove propagation dir '%s', ignoring: %m", p);
+
+        return 0;
+}
+
 static void exec_command_done(ExecCommand *c) {
         assert(c);
 

--- a/src/core/execute.h
+++ b/src/core/execute.h
@@ -453,6 +453,7 @@ void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix);
 
 int exec_context_destroy_runtime_directory(const ExecContext *c, const char *runtime_root);
 int exec_context_destroy_credentials(const ExecContext *c, const char *runtime_root, const char *unit);
+int exec_context_destroy_mount_ns_dir(Unit *u);
 
 const char* exec_context_fdname(const ExecContext *c, int fd_index);
 

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -5778,6 +5778,7 @@ void unit_destroy_runtime_data(Unit *u, const ExecContext *context) {
                 exec_context_destroy_runtime_directory(context, u->manager->prefix[EXEC_DIRECTORY_RUNTIME]);
 
         exec_context_destroy_credentials(context, u->manager->prefix[EXEC_DIRECTORY_RUNTIME], u->id);
+        exec_context_destroy_mount_ns_dir(u);
 }
 
 int unit_clean(Unit *u, ExecCleanMask mask) {


### PR DESCRIPTION
…unit termination

Unit that requires its own mount namespace creates a temporary directory to implement dynamic bind mounts (org.freedesktop.systemd1.Manager.BindMountUnit). However, this directory is never removed and they will accumulate for each unique unit (e.g. templated units of systemd-coredump@).

Attach the auxiliary runtime directory existence to lifetime of other "runtime" only per-unit directories.

(cherry picked from commit b9f976fb45635e09cd709dbedd0afb03d4b73c05)

Resolves: RHEL-19483

<!-- issue-commentator = {"comment-id":"1896119355"} -->