### PR TITLE
(RHEL-22167) man: remove mentions of `systemd.network(5)`

### DIFF
--- a/man/resolvectl.xml
+++ b/man/resolvectl.xml
@@ -181,10 +181,6 @@
 
           <para>Commands <command>dns</command>, <command>domain</command> and <command>nta</command> can take
           a single empty string argument to clear their respective value lists.</para>
-
-          <para>For details about these settings, their possible values and their effect, see the
-          corresponding settings in
-          <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry>.</para>
         </listitem>
       </varlistentry>
 

--- a/man/systemd-resolved.service.xml
+++ b/man/systemd-resolved.service.xml
@@ -81,8 +81,7 @@
     is used), the per-link dynamic settings received over DHCP, information provided via
     <citerefentry><refentrytitle>resolvectl</refentrytitle><manvolnum>1</manvolnum></citerefentry>, and any
     DNS server information made available by other system services. See
-    <citerefentry><refentrytitle>resolved.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry> and
-    <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry> for
+    <citerefentry><refentrytitle>resolved.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry> for
     details about systemd's own configuration files for DNS servers. To improve compatibility,
     <filename>/etc/resolv.conf</filename> is read in order to discover configured system DNS servers, but
     only if it is not a symlink to <filename>/run/systemd/resolve/stub-resolv.conf</filename>,
@@ -187,7 +186,6 @@
 
     <para>Routing of lookups is determined by the per-interface routing domains (search and route-only) and
     global search domains. See
-    <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry> and
     <citerefentry><refentrytitle>resolvectl</refentrytitle><manvolnum>1</manvolnum></citerefentry> for a
     description how those settings are set dynamically and the discussion of <varname>Domains=</varname> in
     <citerefentry><refentrytitle>resolved.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry> for a
@@ -409,7 +407,6 @@ search foobar.com barbar.com
       <citerefentry><refentrytitle>resolvectl</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
       <citerefentry project='man-pages'><refentrytitle>resolv.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
       <citerefentry project='man-pages'><refentrytitle>hosts</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
-      <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>systemd-networkd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
     </para>
   </refsect1>

--- a/man/systemd-timesyncd.service.xml
+++ b/man/systemd-timesyncd.service.xml
@@ -101,7 +101,6 @@
     <para>
       <citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>timesyncd.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
-      <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>systemd-networkd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>systemd-time-wait-sync.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>systemd.special</refentrytitle><manvolnum>7</manvolnum></citerefentry>,

--- a/man/systemd.link.xml
+++ b/man/systemd.link.xml
@@ -1239,9 +1239,6 @@ MACAddress=cb:a9:87:65:43:21</programlisting>
         <refentrytitle>systemd.netdev</refentrytitle><manvolnum>5</manvolnum>
       </citerefentry>,
       <citerefentry>
-        <refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum>
-      </citerefentry>,
-      <citerefentry>
         <refentrytitle>systemd-network-generator.service</refentrytitle><manvolnum>8</manvolnum>
       </citerefentry>
     </para>


### PR DESCRIPTION
This is an attempt to remove all the references to `systemd.network(5)`, as we don't ship that file in RHEL9.

rhel-only

Resolves: RHEL-22167

<!-- issue-commentator = {"comment-id":"1904172459"} -->