### PR TITLE
(RHEL-22427) udev/net_id: introduce naming scheme for RHEL-9.4

### DIFF
--- a/man/systemd.net-naming-scheme.xml
+++ b/man/systemd.net-naming-scheme.xml
@@ -582,6 +582,12 @@
           </listitem>
         </varlistentry>
 
+        <varlistentry>
+           <term><constant>rhel-9.4</constant></term>
+
+           <listitem><para>Same as naming scheme <constant>rhel-9.3</constant>.</para></listitem>
+        </varlistentry>
+
       </variablelist>
 
     <para>Note that <constant>latest</constant> may be used to denote the latest scheme known (to this

--- a/src/shared/netif-naming-scheme.c
+++ b/src/shared/netif-naming-scheme.c
@@ -42,6 +42,7 @@ static const NamingScheme naming_schemes[] = {
         { "rhel-9.1", NAMING_RHEL_9_1 },
         { "rhel-9.2", NAMING_RHEL_9_2 },
         { "rhel-9.3", NAMING_RHEL_9_3 },
+        { "rhel-9.4", NAMING_RHEL_9_4 },
         /* … add more schemes here, as the logic to name devices is updated … */
 
         EXTRA_NET_NAMING_MAP

--- a/src/shared/netif-naming-scheme.h
+++ b/src/shared/netif-naming-scheme.h
@@ -70,6 +70,7 @@ typedef enum NamingSchemeFlags {
         NAMING_RHEL_9_1 = NAMING_RHEL_9_0,
         NAMING_RHEL_9_2 = NAMING_RHEL_9_0,
         NAMING_RHEL_9_3 = NAMING_RHEL_9_0 | NAMING_SR_IOV_R,
+        NAMING_RHEL_9_4 = NAMING_RHEL_9_3,
 
         EXTRA_NET_NAMING_SCHEMES
 


### PR DESCRIPTION
rhel-only

Resolves: RHEL-22427

<!-- issue-commentator = {"comment-id":"1906167703"} -->