### PR TITLE
(RHEL-22443) udev: add new builtin net_driver

### DIFF
--- a/rules.d/50-udev-default.rules.in
+++ b/rules.d/50-udev-default.rules.in
@@ -17,6 +17,8 @@ SUBSYSTEM=="rtc", KERNEL=="rtc0", SYMLINK+="rtc", OPTIONS+="link_priority=-100"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", IMPORT{builtin}="usb_id", IMPORT{builtin}="hwdb --subsystem=usb"
 ENV{MODALIAS}!="", IMPORT{builtin}="hwdb --subsystem=$env{SUBSYSTEM}"
 
+SUBSYSTEM=="net", IMPORT{builtin}="net_driver"
+
 ACTION!="add", GOTO="default_end"
 
 SUBSYSTEM=="tty", KERNEL=="ptmx", GROUP="tty", MODE="0666"

--- a/src/basic/errno-util.h
+++ b/src/basic/errno-util.h
@@ -84,12 +84,21 @@ static inline int errno_or_else(int fallback) {
         return -abs(fallback);
 }
 
+/* abs(3) says: Trying to take the absolute value of the most negative integer is not defined. */
+#define _DEFINE_ABS_WRAPPER(name)                         \
+        static inline bool ERRNO_IS_##name(int r) {       \
+                if (r == INT_MIN)                         \
+                        return false;                     \
+                return ERRNO_IS_NEG_##name(-abs(r));      \
+        }
+
 /* For send()/recv() or read()/write(). */
-static inline bool ERRNO_IS_TRANSIENT(int r) {
-        return IN_SET(abs(r),
-                      EAGAIN,
-                      EINTR);
+static inline bool ERRNO_IS_NEG_TRANSIENT(int r) {
+        return IN_SET(r,
+                      -EAGAIN,
+                      -EINTR);
 }
+_DEFINE_ABS_WRAPPER(TRANSIENT);
 
 /* Hint #1: ENETUNREACH happens if we try to connect to "non-existing" special IP addresses, such as ::5.
  *
@@ -98,79 +107,87 @@ static inline bool ERRNO_IS_TRANSIENT(int r) {
  *
  * Hint #3: When asynchronous connect() on TCP fails because the host never acknowledges a single packet,
  *          kernel tells us that with ETIMEDOUT, see tcp(7). */
-static inline bool ERRNO_IS_DISCONNECT(int r) {
-        return IN_SET(abs(r),
-                      ECONNABORTED,
-                      ECONNREFUSED,
-                      ECONNRESET,
-                      EHOSTDOWN,
-                      EHOSTUNREACH,
-                      ENETDOWN,
-                      ENETRESET,
-                      ENETUNREACH,
-                      ENONET,
-                      ENOPROTOOPT,
-                      ENOTCONN,
-                      EPIPE,
-                      EPROTO,
-                      ESHUTDOWN,
-                      ETIMEDOUT);
+static inline bool ERRNO_IS_NEG_DISCONNECT(int r) {
+        return IN_SET(r,
+                      -ECONNABORTED,
+                      -ECONNREFUSED,
+                      -ECONNRESET,
+                      -EHOSTDOWN,
+                      -EHOSTUNREACH,
+                      -ENETDOWN,
+                      -ENETRESET,
+                      -ENETUNREACH,
+                      -ENONET,
+                      -ENOPROTOOPT,
+                      -ENOTCONN,
+                      -EPIPE,
+                      -EPROTO,
+                      -ESHUTDOWN,
+                      -ETIMEDOUT);
 }
+_DEFINE_ABS_WRAPPER(DISCONNECT);
 
 /* Transient errors we might get on accept() that we should ignore. As per error handling comment in
  * the accept(2) man page. */
-static inline bool ERRNO_IS_ACCEPT_AGAIN(int r) {
-        return ERRNO_IS_DISCONNECT(r) ||
-                ERRNO_IS_TRANSIENT(r) ||
-                abs(r) == EOPNOTSUPP;
+static inline bool ERRNO_IS_NEG_ACCEPT_AGAIN(int r) {
+        return ERRNO_IS_NEG_DISCONNECT(r) ||
+                ERRNO_IS_NEG_TRANSIENT(r) ||
+                r == -EOPNOTSUPP;
 }
+_DEFINE_ABS_WRAPPER(ACCEPT_AGAIN);
 
 /* Resource exhaustion, could be our fault or general system trouble */
-static inline bool ERRNO_IS_RESOURCE(int r) {
-        return IN_SET(abs(r),
-                      EMFILE,
-                      ENFILE,
-                      ENOMEM);
+static inline bool ERRNO_IS_NEG_RESOURCE(int r) {
+        return IN_SET(r,
+                      -EMFILE,
+                      -ENFILE,
+                      -ENOMEM);
 }
+_DEFINE_ABS_WRAPPER(RESOURCE);
 
 /* Seven different errors for "operation/system call/ioctl/socket feature not supported" */
-static inline bool ERRNO_IS_NOT_SUPPORTED(int r) {
-        return IN_SET(abs(r),
-                      EOPNOTSUPP,
-                      ENOTTY,
-                      ENOSYS,
-                      EAFNOSUPPORT,
-                      EPFNOSUPPORT,
-                      EPROTONOSUPPORT,
-                      ESOCKTNOSUPPORT);
+static inline bool ERRNO_IS_NEG_NOT_SUPPORTED(int r) {
+        return IN_SET(r,
+                      -EOPNOTSUPP,
+                      -ENOTTY,
+                      -ENOSYS,
+                      -EAFNOSUPPORT,
+                      -EPFNOSUPPORT,
+                      -EPROTONOSUPPORT,
+                      -ESOCKTNOSUPPORT);
 }
+_DEFINE_ABS_WRAPPER(NOT_SUPPORTED);
 
 /* Two different errors for access problems */
-static inline bool ERRNO_IS_PRIVILEGE(int r) {
-        return IN_SET(abs(r),
-                      EACCES,
-                      EPERM);
+static inline bool ERRNO_IS_NEG_PRIVILEGE(int r) {
+        return IN_SET(r,
+                      -EACCES,
+                      -EPERM);
 }
+_DEFINE_ABS_WRAPPER(PRIVILEGE);
 
 /* Three different errors for "not enough disk space" */
-static inline bool ERRNO_IS_DISK_SPACE(int r) {
-        return IN_SET(abs(r),
-                      ENOSPC,
-                      EDQUOT,
-                      EFBIG);
+static inline bool ERRNO_IS_NEG_DISK_SPACE(int r) {
+        return IN_SET(r,
+                      -ENOSPC,
+                      -EDQUOT,
+                      -EFBIG);
 }
+_DEFINE_ABS_WRAPPER(DISK_SPACE);
 
 /* Three different errors for "this device does not quite exist" */
-static inline bool ERRNO_IS_DEVICE_ABSENT(int r) {
-        return IN_SET(abs(r),
-                      ENODEV,
-                      ENXIO,
-                      ENOENT);
+static inline bool ERRNO_IS_NEG_DEVICE_ABSENT(int r) {
+        return IN_SET(r,
+                      -ENODEV,
+                      -ENXIO,
+                      -ENOENT);
 }
+_DEFINE_ABS_WRAPPER(DEVICE_ABSENT);
 
 /* Quite often we want to handle cases where the backing FS doesn't support extended attributes at all and
  * where it simply doesn't have the requested xattr the same way */
-static inline bool ERRNO_IS_XATTR_ABSENT(int r) {
-        return abs(r) == ENODATA ||
-                ERRNO_IS_NOT_SUPPORTED(r);
+static inline bool ERRNO_IS_NEG_XATTR_ABSENT(int r) {
+        return r == -ENODATA ||
+                ERRNO_IS_NEG_NOT_SUPPORTED(r);
 }
+_DEFINE_ABS_WRAPPER(XATTR_ABSENT);

--- a/src/basic/errno-util.h
+++ b/src/basic/errno-util.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -86,14 +87,16 @@ static inline int errno_or_else(int fallback) {
 
 /* abs(3) says: Trying to take the absolute value of the most negative integer is not defined. */
 #define _DEFINE_ABS_WRAPPER(name)                         \
-        static inline bool ERRNO_IS_##name(int r) {       \
-                if (r == INT_MIN)                         \
+        static inline bool ERRNO_IS_##name(intmax_t r) {  \
+                if (r == INTMAX_MIN)                      \
                         return false;                     \
-                return ERRNO_IS_NEG_##name(-abs(r));      \
+                return ERRNO_IS_NEG_##name(-imaxabs(r));  \
         }
 
+assert_cc(INT_MAX <= INTMAX_MAX);
+
 /* For send()/recv() or read()/write(). */
-static inline bool ERRNO_IS_NEG_TRANSIENT(int r) {
+static inline bool ERRNO_IS_NEG_TRANSIENT(intmax_t r) {
         return IN_SET(r,
                       -EAGAIN,
                       -EINTR);
@@ -107,7 +110,7 @@ _DEFINE_ABS_WRAPPER(TRANSIENT);
  *
  * Hint #3: When asynchronous connect() on TCP fails because the host never acknowledges a single packet,
  *          kernel tells us that with ETIMEDOUT, see tcp(7). */
-static inline bool ERRNO_IS_NEG_DISCONNECT(int r) {
+static inline bool ERRNO_IS_NEG_DISCONNECT(intmax_t r) {
         return IN_SET(r,
                       -ECONNABORTED,
                       -ECONNREFUSED,
@@ -129,7 +132,7 @@ _DEFINE_ABS_WRAPPER(DISCONNECT);
 
 /* Transient errors we might get on accept() that we should ignore. As per error handling comment in
  * the accept(2) man page. */
-static inline bool ERRNO_IS_NEG_ACCEPT_AGAIN(int r) {
+static inline bool ERRNO_IS_NEG_ACCEPT_AGAIN(intmax_t r) {
         return ERRNO_IS_NEG_DISCONNECT(r) ||
                 ERRNO_IS_NEG_TRANSIENT(r) ||
                 r == -EOPNOTSUPP;
@@ -137,7 +140,7 @@ static inline bool ERRNO_IS_NEG_ACCEPT_AGAIN(int r) {
 _DEFINE_ABS_WRAPPER(ACCEPT_AGAIN);
 
 /* Resource exhaustion, could be our fault or general system trouble */
-static inline bool ERRNO_IS_NEG_RESOURCE(int r) {
+static inline bool ERRNO_IS_NEG_RESOURCE(intmax_t r) {
         return IN_SET(r,
                       -EMFILE,
                       -ENFILE,
@@ -146,7 +149,7 @@ static inline bool ERRNO_IS_NEG_RESOURCE(int r) {
 _DEFINE_ABS_WRAPPER(RESOURCE);
 
 /* Seven different errors for "operation/system call/ioctl/socket feature not supported" */
-static inline bool ERRNO_IS_NEG_NOT_SUPPORTED(int r) {
+static inline bool ERRNO_IS_NEG_NOT_SUPPORTED(intmax_t r) {
         return IN_SET(r,
                       -EOPNOTSUPP,
                       -ENOTTY,
@@ -159,7 +162,7 @@ static inline bool ERRNO_IS_NEG_NOT_SUPPORTED(int r) {
 _DEFINE_ABS_WRAPPER(NOT_SUPPORTED);
 
 /* Two different errors for access problems */
-static inline bool ERRNO_IS_NEG_PRIVILEGE(int r) {
+static inline bool ERRNO_IS_NEG_PRIVILEGE(intmax_t r) {
         return IN_SET(r,
                       -EACCES,
                       -EPERM);
@@ -167,7 +170,7 @@ static inline bool ERRNO_IS_NEG_PRIVILEGE(int r) {
 _DEFINE_ABS_WRAPPER(PRIVILEGE);
 
 /* Three different errors for "not enough disk space" */
-static inline bool ERRNO_IS_NEG_DISK_SPACE(int r) {
+static inline bool ERRNO_IS_NEG_DISK_SPACE(intmax_t r) {
         return IN_SET(r,
                       -ENOSPC,
                       -EDQUOT,
@@ -176,7 +179,7 @@ static inline bool ERRNO_IS_NEG_DISK_SPACE(int r) {
 _DEFINE_ABS_WRAPPER(DISK_SPACE);
 
 /* Three different errors for "this device does not quite exist" */
-static inline bool ERRNO_IS_NEG_DEVICE_ABSENT(int r) {
+static inline bool ERRNO_IS_NEG_DEVICE_ABSENT(intmax_t r) {
         return IN_SET(r,
                       -ENODEV,
                       -ENXIO,
@@ -186,7 +189,7 @@ _DEFINE_ABS_WRAPPER(DEVICE_ABSENT);
 
 /* Quite often we want to handle cases where the backing FS doesn't support extended attributes at all and
  * where it simply doesn't have the requested xattr the same way */
-static inline bool ERRNO_IS_NEG_XATTR_ABSENT(int r) {
+static inline bool ERRNO_IS_NEG_XATTR_ABSENT(intmax_t r) {
         return r == -ENODATA ||
                 ERRNO_IS_NEG_NOT_SUPPORTED(r);
 }

--- a/src/test/test-errno-util.c
+++ b/src/test/test-errno-util.c
@@ -52,6 +52,19 @@ TEST(ERRNO_IS_TRANSIENT) {
         assert_se(!ERRNO_IS_NEG_TRANSIENT(EINTR));
         assert_se( ERRNO_IS_TRANSIENT(-EINTR));
         assert_se( ERRNO_IS_TRANSIENT(EINTR));
+
+        /* Test with type wider than int */
+        ssize_t r = -EAGAIN;
+        assert_se( ERRNO_IS_NEG_TRANSIENT(r));
+
+        /* On 64-bit arches, now (int) r == EAGAIN */
+        r = SSIZE_MAX - EAGAIN + 1;
+        assert_se(!ERRNO_IS_NEG_TRANSIENT(r));
+
+        assert_se(!ERRNO_IS_NEG_TRANSIENT(INT_MAX));
+        assert_se(!ERRNO_IS_NEG_TRANSIENT(INT_MIN));
+        assert_se(!ERRNO_IS_NEG_TRANSIENT(INTMAX_MAX));
+        assert_se(!ERRNO_IS_NEG_TRANSIENT(INTMAX_MIN));
 }
 
 DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/test/test-errno-util.c
+++ b/src/test/test-errno-util.c
@@ -47,4 +47,11 @@ TEST(STRERROR_OR_ELSE) {
         log_info("STRERROR_OR_ELSE(-EPERM, \"EOF\") → %s", STRERROR_OR_EOF(-EPERM));
 }
 
+TEST(ERRNO_IS_TRANSIENT) {
+        assert_se( ERRNO_IS_NEG_TRANSIENT(-EINTR));
+        assert_se(!ERRNO_IS_NEG_TRANSIENT(EINTR));
+        assert_se( ERRNO_IS_TRANSIENT(-EINTR));
+        assert_se( ERRNO_IS_TRANSIENT(EINTR));
+}
+
 DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/udev/meson.build
+++ b/src/udev/meson.build
@@ -35,6 +35,7 @@ libudevd_core_sources = files(
         'udev-builtin-hwdb.c',
         'udev-builtin-input_id.c',
         'udev-builtin-keyboard.c',
+        'udev-builtin-net_driver.c',
         'udev-builtin-net_id.c',
         'udev-builtin-net_setup_link.c',
         'udev-builtin-path_id.c',

--- a/src/udev/net/link-config.c
+++ b/src/udev/net/link-config.c
@@ -362,7 +362,6 @@ Link *link_free(Link *link) {
 
         sd_device_unref(link->device);
         free(link->kind);
-        free(link->driver);
         strv_free(link->altnames);
         return mfree(link);
 }
@@ -415,8 +414,8 @@ int link_new(LinkConfigContext *ctx, sd_netlink **rtnl, sd_device *device, Link 
                         log_link_debug_errno(link, r, "Failed to get permanent hardware address, ignoring: %m");
         }
 
-        r = ethtool_get_driver(&ctx->ethtool_fd, link->ifname, &link->driver);
-        if (r < 0)
+        r = sd_device_get_property_value(link->device, "ID_NET_DRIVER", &link->driver);
+        if (r < 0 && r != -ENOENT)
                 log_link_debug_errno(link, r, "Failed to get driver, ignoring: %m");
 
         *ret = TAKE_PTR(link);

--- a/src/udev/net/link-config.h
+++ b/src/udev/net/link-config.h
@@ -34,7 +34,7 @@ typedef struct Link {
         sd_device_action_t action;
 
         char *kind;
-        char *driver;
+        const char *driver;
         uint16_t iftype;
         uint32_t flags;
         struct hw_addr_data hw_addr;

--- a/src/udev/udev-builtin-net_driver.c
+++ b/src/udev/udev-builtin-net_driver.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "alloc-util.h"
+#include "device-util.h"
+#include "errno-util.h"
+#include "ethtool-util.h"
+#include "fd-util.h"
+#include "log.h"
+#include "string-util.h"
+#include "udev-builtin.h"
+
+static int builtin_net_driver_set_driver(UdevEvent *event, int argc, char **argv, bool test) {
+        sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
+        _cleanup_close_ int ethtool_fd = -EBADF;
+        _cleanup_free_ char *driver = NULL;
+        const char *sysname;
+        int r;
+
+        r = sd_device_get_sysname(dev, &sysname);
+        if (r < 0)
+                return log_device_warning_errno(dev, r, "Failed to get sysname: %m");
+
+        r = ethtool_get_driver(&ethtool_fd, sysname, &driver);
+        if (ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
+                log_device_debug_errno(dev, r, "Querying driver name via ethtool API is not supported by device '%s', ignoring: %m", sysname);
+                return 0;
+        }
+        if (r == -ENODEV) {
+                log_device_debug_errno(dev, r, "Device already vanished, ignoring.");
+                return 0;
+        }
+        if (r < 0)
+                return log_device_warning_errno(dev, r, "Failed to get driver for '%s': %m", sysname);
+
+        return udev_builtin_add_property(event->dev, test, "ID_NET_DRIVER", driver);
+}
+
+const UdevBuiltin udev_builtin_net_driver = {
+        .name = "net_driver",
+        .cmd = builtin_net_driver_set_driver,
+        .help = "Set driver for network device",
+        .run_once = true,
+};

--- a/src/udev/udev-builtin-net_setup_link.c
+++ b/src/udev/udev-builtin-net_setup_link.c
@@ -26,9 +26,6 @@ static int builtin_net_setup_link(UdevEvent *event, int argc, char **argv, bool 
         if (r < 0)
                 return log_device_warning_errno(dev, r, "Failed to get link information: %m");
 
-        if (link->driver)
-                udev_builtin_add_property(dev, test, "ID_NET_DRIVER", link->driver);
-
         r = link_get_config(ctx, link);
         if (r < 0) {
                 if (r == -ENOENT) {

--- a/src/udev/udev-builtin.c
+++ b/src/udev/udev-builtin.c
@@ -22,6 +22,7 @@ static const UdevBuiltin *const builtins[_UDEV_BUILTIN_MAX] = {
 #if HAVE_KMOD
         [UDEV_BUILTIN_KMOD] = &udev_builtin_kmod,
 #endif
+        [UDEV_BUILTIN_NET_DRIVER] = &udev_builtin_net_driver,
         [UDEV_BUILTIN_NET_ID] = &udev_builtin_net_id,
         [UDEV_BUILTIN_NET_LINK] = &udev_builtin_net_setup_link,
         [UDEV_BUILTIN_PATH_ID] = &udev_builtin_path_id,

--- a/src/udev/udev-builtin.h
+++ b/src/udev/udev-builtin.h
@@ -19,6 +19,7 @@ typedef enum UdevBuiltinCommand {
 #if HAVE_KMOD
         UDEV_BUILTIN_KMOD,
 #endif
+        UDEV_BUILTIN_NET_DRIVER,
         UDEV_BUILTIN_NET_ID,
         UDEV_BUILTIN_NET_LINK,
         UDEV_BUILTIN_PATH_ID,
@@ -63,6 +64,7 @@ extern const UdevBuiltin udev_builtin_keyboard;
 #if HAVE_KMOD
 extern const UdevBuiltin udev_builtin_kmod;
 #endif
+extern const UdevBuiltin udev_builtin_net_driver;
 extern const UdevBuiltin udev_builtin_net_id;
 extern const UdevBuiltin udev_builtin_net_setup_link;
 extern const UdevBuiltin udev_builtin_path_id;


### PR DESCRIPTION
Currently the ID_NET_DRIVER is set in net_setup_link builtin. But this is called pretty late in the udev processing chain.

Right now in some custom rules it was workarounded by calling ethtool binary directly, which is ugly.

So let's split this code to a separate builtin.

(cherry picked from commit 2b5b25f123ceb89b3ff45b2380db1c8a88b046d9)

Resolves: RHEL-22443

<!-- issue-commentator = {"comment-id":"1906397404"} -->