### PR TITLE
(RHEL-7026) doc: add missing `<listitem>` to `systemd.net-naming-scheme.xml`

### DIFF
--- a/man/systemd.net-naming-scheme.xml
+++ b/man/systemd.net-naming-scheme.xml
@@ -483,19 +483,19 @@
         <varlistentry>
           <term><constant>rhel-8.1</constant></term>
 
-          <para>Same as naming scheme <constant>rhel-8.0</constant>.</para>
+          <listitem><para>Same as naming scheme <constant>rhel-8.0</constant>.</para></listitem>
         </varlistentry>
 
         <varlistentry>
           <term><constant>rhel-8.2</constant></term>
 
-          <para>Same as naming scheme <constant>rhel-8.0</constant>.</para>
+          <listitem><para>Same as naming scheme <constant>rhel-8.0</constant>.</para></listitem>
         </varlistentry>
 
         <varlistentry>
           <term><constant>rhel-8.3</constant></term>
 
-          <para>Same as naming scheme <constant>rhel-8.0</constant>.</para>
+          <listitem><para>Same as naming scheme <constant>rhel-8.0</constant>.</para></listitem>
         </varlistentry>
 
         <varlistentry>
@@ -511,13 +511,13 @@
         <varlistentry>
           <term><constant>rhel-8.5</constant></term>
 
-          <para>Same as naming scheme <constant>rhel-8.4</constant>.</para>
+          <listitem><para>Same as naming scheme <constant>rhel-8.4</constant>.</para></listitem>
         </varlistentry>
 
         <varlistentry>
           <term><constant>rhel-8.6</constant></term>
 
-          <para>Same as naming scheme <constant>rhel-8.4</constant>.</para>
+          <listitem><para>Same as naming scheme <constant>rhel-8.4</constant>.</para></listitem>
         </varlistentry>
 
         <varlistentry>
@@ -538,19 +538,19 @@
         <varlistentry>
           <term><constant>rhel-8.8</constant></term>
 
-          <para>Same as naming scheme <constant>rhel-8.7</constant>.</para>
+          <listitem><para>Same as naming scheme <constant>rhel-8.7</constant>.</para></listitem>
         </varlistentry>
 
         <varlistentry>
           <term><constant>rhel-8.9</constant></term>
 
-          <para>Same as naming scheme <constant>rhel-8.7</constant>.</para>
+          <listitem><para>Same as naming scheme <constant>rhel-8.7</constant>.</para></listitem>
         </varlistentry>
 
         <varlistentry>
           <term><constant>rhel-8.10</constant></term>
 
-          <para>Same as naming scheme <constant>rhel-8.7</constant>.</para>
+          <listitem><para>Same as naming scheme <constant>rhel-8.7</constant>.</para></listitem>
         </varlistentry>
 
         <varlistentry>


### PR DESCRIPTION
follow-up to: dcc59dffa5116bf96618065cd60742cb660224b8

rhel-only

Related: RHEL-7026

<!-- issue-commentator = {"comment-id":"1935914421"} -->