### PR TITLE
(RHEL-16952) units: fix typo in Condition in systemd-boot-system-token

### DIFF
--- a/units/systemd-boot-system-token.service
+++ b/units/systemd-boot-system-token.service
@@ -17,8 +17,8 @@ Conflicts=shutdown.target initrd-switch-root.target
 Before=shutdown.target initrd-switch-root.target
 
 # Only run this if the boot loader can support random seed initialization.
-ConditionPathExists|=/sys/firmware/efi/efivars/LoaderFeatures-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
-ConditionPathExists|=/sys/firmware/efi/efivars/StubFeatures-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
+ConditionPathExists=|/sys/firmware/efi/efivars/LoaderFeatures-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
+ConditionPathExists=|/sys/firmware/efi/efivars/StubFeatures-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
 
 # Only run this if there is no system token defined yet
 ConditionPathExists=!/sys/firmware/efi/efivars/LoaderSystemToken-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f


### PR DESCRIPTION
/lib/systemd/system/systemd-boot-system-token.service:20: Unknown key name 'ConditionPathExists|' in section 'Unit', ignoring

Follow-up for 0a1d8ac77a21ae0741bdf4af08f3a71354805ff1

(cherry picked from commit 0f6d54ca47662f1386ada65ed179a1afd6e727e4)

Related: RHEL-16952

<!-- issue-commentator = {"comment-id":"1956584662"} -->