### PR TITLE
(RHEL-27383) udev: raise RLIMIT_NOFILE as high as we can

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -18,7 +18,9 @@ srpm_build_deps: []
 actions:
   post-upstream-clone:
     # Use the CentOS Stream specfile
-    - "git clone https://gitlab.com/redhat/centos-stream/rpms/systemd.git .packit_rpm --depth=1"
+    - "git clone https://gitlab.com/redhat/centos-stream/rpms/systemd.git .packit_rpm"
+    # Checkout the 9.3 revision (v252-18)
+    - "git -C .packit_rpm checkout ea71a492"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
     # Drop all patches, since they're already included in the tarball

--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -55,6 +55,7 @@
 #include "pretty-print.h"
 #include "proc-cmdline.h"
 #include "process-util.h"
+#include "rlimit-util.h"
 #include "selinux-util.h"
 #include "signal-util.h"
 #include "socket-util.h"
@@ -2039,6 +2040,9 @@ int run_udevd(int argc, char *argv[]) {
         r = mac_selinux_init();
         if (r < 0)
                 return r;
+
+        /* Make sure we can have plenty fds (for example for pidfds) */
+        (void) rlimit_nofile_bump(-1);
 
         r = RET_NERRNO(mkdir("/run/udev", 0755));
         if (r < 0 && r != -EEXIST)

--- a/test/knot-data/knot.conf
+++ b/test/knot-data/knot.conf
@@ -51,6 +51,7 @@ policy:
       ds-push: parent_zone_server
       ksk-lifetime: 365d
       ksk-submission: parent_zone_sbm
+      nsec3-iterations: 0
       nsec3: on
       propagation-delay: 1s
       signing-threads: 4

--- a/test/knot-data/knot.conf
+++ b/test/knot-data/knot.conf
@@ -52,7 +52,6 @@ policy:
       ksk-lifetime: 365d
       ksk-submission: parent_zone_sbm
       nsec3: on
-      nsec3-iterations: 10
       propagation-delay: 1s
       signing-threads: 4
       zone-max-ttl: 1s

--- a/test/units/testsuite-07.main-PID-change.sh
+++ b/test/units/testsuite-07.main-PID-change.sh
@@ -151,6 +151,8 @@ systemd-run --unit=test-mainpidsh3.service \
             -p RuntimeDirectory=mainpidsh3 \
             -p PIDFile=/run/mainpidsh3/pid \
             -p DynamicUser=1 \
+            `# Make sanitizers happy when DynamicUser=1 pulls in instrumented systemd NSS modules` \
+            -p EnvironmentFile=-/usr/lib/systemd/systemd-asan-env \
             -p TimeoutStartSec=2s \
             /dev/shm/test-mainpid3.sh \
     && { echo 'unexpected success'; exit 1; }


### PR DESCRIPTION
We might need a lot of fds on large systems, hence raise RLIMIT_NOFILE to what the service manager allows us, which is quite a lot these days.

udev already sets FORK_RLIMIT_NOFILE_SAFE when forking of chilren, thus ensuring that forked off processes get their RLIMIT_NOFILE soft limit reset to 1K for compat with crappy old select().

Replaces: #29298
Fixes: #28583
(cherry picked from commit 1617424ce76d797d081dd6cb1082b954c4d2bf38)

Resolves: RHEL-27383

<!-- issue-commentator = {"comment-id":"1970705198"} -->