### PR TITLE
(RHEL-16182) units: change assert to condition to skip running in initrd/os

### DIFF
--- a/units/systemd-pcrfs-root.service.in
+++ b/units/systemd-pcrfs-root.service.in
@@ -14,7 +14,7 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 After=systemd-pcrmachine.service
 Before=shutdown.target
-AssertPathExists=!/etc/initrd-release
+ConditionPathExists=!/etc/initrd-release
 ConditionSecurity=tpm2
 ConditionPathExists=/sys/firmware/efi/efivars/StubPcrKernelImage-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
 

--- a/units/systemd-pcrfs@.service.in
+++ b/units/systemd-pcrfs@.service.in
@@ -15,7 +15,7 @@ BindsTo=%i.mount
 Conflicts=shutdown.target
 After=%i.mount systemd-pcrfs-root.service
 Before=shutdown.target
-AssertPathExists=!/etc/initrd-release
+ConditionPathExists=!/etc/initrd-release
 ConditionSecurity=tpm2
 ConditionPathExists=/sys/firmware/efi/efivars/StubPcrKernelImage-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
 

--- a/units/systemd-pcrmachine.service.in
+++ b/units/systemd-pcrmachine.service.in
@@ -13,7 +13,7 @@ Documentation=man:systemd-pcrmachine.service(8)
 DefaultDependencies=no
 Conflicts=shutdown.target
 Before=sysinit.target shutdown.target
-AssertPathExists=!/etc/initrd-release
+ConditionPathExists=!/etc/initrd-release
 ConditionSecurity=tpm2
 ConditionPathExists=/sys/firmware/efi/efivars/StubPcrKernelImage-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
 

--- a/units/systemd-pcrphase-initrd.service.in
+++ b/units/systemd-pcrphase-initrd.service.in
@@ -13,7 +13,7 @@ Documentation=man:systemd-pcrphase-initrd.service(8)
 DefaultDependencies=no
 Conflicts=shutdown.target initrd-switch-root.target
 Before=sysinit.target cryptsetup-pre.target cryptsetup.target shutdown.target initrd-switch-root.target systemd-sysext.service
-AssertPathExists=/etc/initrd-release
+ConditionPathExists=/etc/initrd-release
 ConditionSecurity=tpm2
 ConditionPathExists=/sys/firmware/efi/efivars/StubPcrKernelImage-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
 

--- a/units/systemd-pcrphase-sysinit.service.in
+++ b/units/systemd-pcrphase-sysinit.service.in
@@ -14,7 +14,7 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 After=sysinit.target
 Before=basic.target shutdown.target
-AssertPathExists=!/etc/initrd-release
+ConditionPathExists=!/etc/initrd-release
 ConditionSecurity=tpm2
 ConditionPathExists=/sys/firmware/efi/efivars/StubPcrKernelImage-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
 

--- a/units/systemd-pcrphase.service.in
+++ b/units/systemd-pcrphase.service.in
@@ -12,7 +12,7 @@ Description=TPM2 PCR Barrier (User)
 Documentation=man:systemd-pcrphase.service(8)
 After=remote-fs.target remote-cryptsetup.target
 Before=systemd-user-sessions.service
-AssertPathExists=!/etc/initrd-release
+ConditionPathExists=!/etc/initrd-release
 ConditionSecurity=tpm2
 ConditionPathExists=/sys/firmware/efi/efivars/StubPcrKernelImage-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
 


### PR DESCRIPTION
These units are also present in the initrd, so instead of an assert, just use a condition so they are skipped where they need to be skipped.

Fixes https://github.com/systemd/systemd/issues/26358

(cherry picked from commit 7ef09e2099a4f97ad40748d6b7c735b45aa4c990)

Related: RHEL-16182

---

Noticed this while testing #238. This doesn't affect RHEL 9 directly (yet), since RHEL 9's dracut doesn't pull in these files, but once that change gets backported we'd start seeing fails in journal. Since we're going to do another RHEL 9 build anyway, let's throw this one in as well.

<!-- issue-commentator = {"comment-id":"1971176871"} -->