### PR TITLE
(RHEL-26133) efi: alignment of the PE file has to be at least 512 bytes

### DIFF
--- a/src/boot/efi/meson.build
+++ b/src/boot/efi/meson.build
@@ -485,6 +485,7 @@ foreach tuple : [['systemd-boot@0@.@1@', systemd_boot_objects, false, 'systemd-b
                            '-j', '.sdata',
                            '-j', '.sdmagic',
                            '-j', '.text',
+                           '--file-alignment=512',
                            '--section-alignment=512',
                            efi_format,
                            '@INPUT@', '@OUTPUT@'],


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/debug/pe-format?redirectedfrom=MSDN#optional-header-windows-specific-fields-image-only

Resolves: RHEL-26133

RHEL-only

[msekleta: this is RHEL-only because upstream no longer uses objcopy to create PE files]

<!-- issue-commentator = {"comment-id":"1971574963"} -->