### PR TITLE
(RHEL-26133) efi: force .sbat and .sdmagic sections to be 512 bytes

### DIFF
--- a/src/boot/efi/addon.c
+++ b/src/boot/efi/addon.c
@@ -4,7 +4,7 @@
 #include "macro-fundamental.h"
 
 /* Magic string for recognizing our own binaries */
-_used_ _section_(".sdmagic") static const char magic[] =
+_used_ _section_(".sdmagic") static const char magic[512] =
         "#### LoaderInfo: systemd-addon " GIT_VERSION " ####";
 
 /* This is intended to carry data, not to be executed */

--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -35,7 +35,7 @@
 #define TEXT_ATTR_SWAP(c) EFI_TEXT_ATTR(((c) & 0b11110000) >> 4, (c) & 0b1111)
 
 /* Magic string for recognizing our own binaries */
-_used_ _section_(".sdmagic") static const char magic[] =
+_used_ _section_(".sdmagic") static const char magic[512] =
         "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
 
 /* Makes systemd-boot available from \EFI\Linux\ for testing purposes. */

--- a/src/boot/efi/secure-boot.c
+++ b/src/boot/efi/secure-boot.c
@@ -33,7 +33,7 @@ SecureBootMode secure_boot_mode(void) {
 }
 
 #ifdef SBAT_DISTRO
-static const char sbat[] _used_ _section_(".sbat") = SBAT_SECTION_TEXT;
+static const char sbat[512] _used_ _section_(".sbat") = SBAT_SECTION_TEXT;
 #endif
 
 EFI_STATUS secure_boot_enroll_at(EFI_FILE *root_dir, const char16_t *path) {

--- a/src/boot/efi/stub.c
+++ b/src/boot/efi/stub.c
@@ -20,7 +20,7 @@
 #include "vmm.h"
 
 /* magic string to find in the binary image */
-_used_ _section_(".sdmagic") static const char magic[] = "#### LoaderInfo: systemd-stub " GIT_VERSION " ####";
+_used_ _section_(".sdmagic") static const char magic[512] = "#### LoaderInfo: systemd-stub " GIT_VERSION " ####";
 
 static EFI_STATUS combine_initrd(
                 EFI_PHYSICAL_ADDRESS initrd_base, size_t initrd_size,


### PR DESCRIPTION
In https://issues.redhat.com/browse/RHEL-26133 we're having issues with section alignment when objcopy from older bintils is used. IIUC, the short sections are causing the following section to be not aligned. To sidestep the problem, let's make the sections 512 bytes.

```console
$ diff -u <(objdump -h build/src/boot/efi/linuxx64.efi.stub.0) <(objdump -h build/src/boot/efi/linuxx64.efi.stub)|cat --- /proc/self/fd/11	2024-03-22 11:58:47.427094850 +0100 +++ /proc/self/fd/13	2024-03-22 11:58:47.422094852 +0100 @@ -1,5 +1,5 @@

-build/src/boot/efi/linuxx64.efi.stub.0:     file format pei-x86-64
+build/src/boot/efi/linuxx64.efi.stub:     file format pei-x86-64

 Sections:
 Idx Name          Size      VMA               LMA               File off  Algn
@@ -15,7 +15,7 @@
                   CONTENTS, ALLOC, LOAD, READONLY, DATA
   5 .dynsym       00000018  0000000000026000  0000000000026000  0001d000  2**2
                   CONTENTS, ALLOC, LOAD, READONLY, DATA
-  6 .sbat         000000e6  00000000000289e0  00000000000289e0  0001d200  2**2
+  6 .sbat         00000200  00000000000289e0  00000000000289e0  0001d200  2**2
                   CONTENTS, ALLOC, LOAD, READONLY, DATA
-  7 .sdmagic      00000038  0000000000028ae0  0000000000028ae0  0001d400  2**2
+  7 .sdmagic      00000200  0000000000028be0  0000000000028be0  0001d400  2**2
                   CONTENTS, ALLOC, LOAD, READONLY, DATA
```

<!-- issue-commentator = {"comment-id":"2014856066"} -->