### PR TITLE
(RHEL-32259) execute: Pass AT_FDCWD instead of -1

### DIFF
--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -2662,6 +2662,7 @@ static int load_credential(
         assert(id);
         assert(path);
         assert(unit);
+        assert(read_dfd >= 0 || read_dfd == AT_FDCWD);
         assert(write_dfd >= 0);
         assert(left);
 
@@ -2888,7 +2889,7 @@ static int acquire_credentials(
                                         lc->path,
                                         lc->encrypted,
                                         unit,
-                                        -1,
+                                        AT_FDCWD,
                                         dfd,
                                         uid,
                                         ownership_ok,


### PR DESCRIPTION
Let's enforce that callers pass AT_FDCWD as read_dfd to load_credential() to avoid an assert() in read_full_file_full() if read_dfd is -1.

(cherry picked from commit 661e4251a5b157d1aee1df98fbd2f0c95285ebba)

Resolves: RHEL-32259

<!-- issue-commentator = {"comment-id":"2045318042"} -->