### PR TITLE
(RHEL-30372) ukify: make the test happy with the latest OpenSSL 

### DIFF
--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -850,7 +850,7 @@ def test_key_cert_generation(tmpdir):
         '-noout',
     ], text = True)
     assert 'Certificate' in out
-    assert re.search('Issuer: CN\s?=\s?SecureBoot signing key on host', out)
+    assert re.search(r'Issuer: CN\s?=\s?SecureBoot signing key on host', out)
 
 if __name__ == '__main__':
     sys.exit(pytest.main(sys.argv))

--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -850,7 +850,7 @@ def test_key_cert_generation(tmpdir):
         '-noout',
     ], text = True)
     assert 'Certificate' in out
-    assert 'Issuer: CN = SecureBoot signing key on host' in out
+    assert re.search('Issuer: CN\s?=\s?SecureBoot signing key on host', out)
 
 if __name__ == '__main__':
     sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
Which dropped some whitespaces in the output:
```
$ openssl version
OpenSSL 3.2.0 23 Nov 2023 (Library: OpenSSL 3.2.0 23 Nov 2023)
$ openssl x509 -in cert.pem -text -noout | grep Issuer
        Issuer: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd

$ openssl version
OpenSSL 3.0.9 30 May 2023 (Library: OpenSSL 3.0.9 30 May 2023)
$ openssl x509 -in cert.pem -text -noout | grep Issuer
        Issuer: C = XX, L = Default City, O = Default Company Ltd

Making test-ukify unhappy:

>       assert 'Issuer: CN = SecureBoot signing key on host' in out
E       AssertionError: assert 'Issuer: CN = SecureBoot signing key on host' in '<...snip...>Issuer: CN=SecureBoot signing key on host archlinux2\n...'
```
(cherry picked from commit 338ed5bea4fcd0b5b1cdcfb96a789edf6251bbdd)

Related: RHEL-30372

<!-- issue-commentator = {"comment-id":"2075733706"} -->