### PR TITLE
(RHEL-36284) bootspec: fix null-dereference-read

### DIFF
--- a/src/shared/bootspec.c
+++ b/src/shared/bootspec.c
@@ -996,6 +996,8 @@ static int boot_config_find(const BootConfig *config, const char *id) {
         if (id[0] == '@') {
                 if (!strcaseeq(id, "@saved"))
                         return -1;
+                if (!config->entry_selected)
+                        return -1;
                 id = config->entry_selected;
         }
 

--- a/test/fuzz/fuzz-bootspec/clusterfuzz-testcase-minimized-fuzz-bootspec-5731869371269120
+++ b/test/fuzz/fuzz-bootspec/clusterfuzz-testcase-minimized-fuzz-bootspec-5731869371269120
@@ -1,0 +1,1 @@
+{"config":"default @saved","loader":[""]}


### PR DESCRIPTION
Fixes [oss-fuzz#53578](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53578).

(cherry picked from commit 46dc071985ff487f5ccf20808531168a6add73d3)

Resolves: RHEL-36284

<!-- issue-commentator = {"comment-id":"2109912428"} -->