### PR TITLE
(RHEL-20322) fix: prefix of dmesg pstore files

### DIFF
--- a/src/pstore/pstore.c
+++ b/src/pstore/pstore.c
@@ -233,7 +233,9 @@ static int process_dmesg_files(PStoreList *list) {
                 if (!startswith(pe->dirent.d_name, "dmesg-"))
                         continue;
 
-                if ((p = startswith(pe->dirent.d_name, "dmesg-efi-"))) {
+                /* The linux kernel changed the prefix from dmesg-efi- to dmesg-efi_pstore-
+                 * so now we have to handle both cases. */
+                if ((p = STARTSWITH_SET(pe->dirent.d_name, "dmesg-efi-", "dmesg-efi_pstore-"))) {
                         /* For the EFI backend, the 3 least significant digits of record id encodes a
                          * "count" number, the next 2 least significant digits for the dmesg part
                          * (chunk) number, and the remaining digits as the timestamp.  See


### PR DESCRIPTION
A change in the kernel[1] renamed the prefix of the pstore files from `dmesg-efi-` to `dmesg-efi_pstore-`.

[1]
https://git.kernel.org/linus/893c5f1de620

(cherry picked from commit ef87c84e812cbdca4ef160fb0536d1f1bc6a2400)

Resolves: RHEL-20322

<!-- issue-commentator = {"comment-id":"2111819042"} -->