### PR TITLE
(RHEL-35994) kernel-install: fix uki-copy deinstall

### DIFF
--- a/src/kernel-install/90-uki-copy.install
+++ b/src/kernel-install/90-uki-copy.install
@@ -26,8 +26,6 @@ KERNEL_VERSION="${2:?}"
 ENTRY_DIR_ABS="$3"
 KERNEL_IMAGE="$4"
 
-[ "$KERNEL_INSTALL_LAYOUT" = "uki" ] || exit 0
-
 ENTRY_TOKEN="$KERNEL_INSTALL_ENTRY_TOKEN"
 BOOT_ROOT="$KERNEL_INSTALL_BOOT_ROOT"
 
@@ -47,6 +45,8 @@ case "$COMMAND" in
         exit 0
         ;;
 esac
+
+[ "$KERNEL_INSTALL_LAYOUT" = "uki" ] || exit 0
 
 if ! [ -d "$UKI_DIR" ]; then
     [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] && echo "creating $UKI_DIR"


### PR DESCRIPTION
For "kernel-install remove ..." only the kernel version is passed, not the kernel image.  So auto-detecting KERNEL_INSTALL_IMAGE_TYPE and setting KERNEL_INSTALL_LAYOUT does not work for uninstall.

The 90-uki-copy.install plugin must consider this and *not* exit early for the "remove" command, otherwise $BOOT_ROOT will be filled with stale kernel images.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>

(cherry picked from commit 3037616d8ed68f3263746e3c6399d4a05242068b)

Resolves: RHEL-35994

<!-- issue-commentator = {"comment-id":"2112402728"} -->