### PR TITLE
(RHEL-30372) ci(packit): explicitly clone `c9s` branch

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -18,7 +18,7 @@ srpm_build_deps: []
 actions:
   post-upstream-clone:
     # Use the CentOS Stream specfile
-    - "git clone https://gitlab.com/redhat/centos-stream/rpms/systemd.git .packit_rpm --depth=1"
+    - "git clone -b c9s https://gitlab.com/redhat/centos-stream/rpms/systemd.git .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
     # Drop all patches, since they're already included in the tarball


### PR DESCRIPTION
Once default branch is changed to `c10s` the current configuration could stop working.

rhel-only

Related: RHEL-30372

<!-- issue-commentator = {"comment-id":"2117462925"} -->