### PR TITLE
(RHEL-6589) libsystemd: link with '-z nodelete'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2004,6 +2004,8 @@ libsystemd = shared_library(
         version : libsystemd_version,
         include_directories : libsystemd_includes,
         link_args : ['-shared',
+                     # Make sure our library is never deleted from memory, so that our open logging fds don't leak on dlopen/dlclose cycles.
+                     '-z', 'nodelete',
                      '-Wl,--version-script=' + libsystemd_sym_path],
         link_with : [libbasic,
                      libbasic_gcrypt,


### PR DESCRIPTION
We want to avoid reinitialization of our global variables with static storage duration in case we get dlopened multiple times by the same application. This will avoid potential resource leaks that could have happened otherwise (e.g. leaking journal socket fd).

Resolves: RHEL-6589

<!-- issue-commentator = {"comment-id":"2127458641"} -->