### PR TITLE
(RHEL-30372) ci(src-git): add RHEL-9.1 and RHEL-9.1.z to allowed versions

### DIFF
--- a/.github/tracker-validator.yml
+++ b/.github/tracker-validator.yml
@@ -8,6 +8,8 @@ products:
   - CentOS Stream 9
   - rhel-9.0.0
   - rhel-9.0.0.z
+  - rhel-9.1.0
+  - rhel-9.1.0.z
   - rhel-9.2.0
   - rhel-9.2.0.z
   - rhel-9.3.0


### PR DESCRIPTION
rhel-only

Related: RHEL-30372

<!-- issue-commentator = {"comment-id":"2127565175"} -->