### PR TITLE
(RHEL-30372) Drop /dev test in test-mountpoint-util

### DIFF
--- a/src/test/test-mountpoint-util.c
+++ b/src/test/test-mountpoint-util.c
@@ -138,11 +138,6 @@ TEST(path_is_mount_point) {
         assert_se(path_is_mount_point("/proc/1/", NULL, AT_SYMLINK_FOLLOW) == 0);
         assert_se(path_is_mount_point("/proc/1/", NULL, 0) == 0);
 
-        assert_se(path_is_mount_point("/dev", NULL, AT_SYMLINK_FOLLOW) > 0);
-        assert_se(path_is_mount_point("/dev", NULL, 0) > 0);
-        assert_se(path_is_mount_point("/dev/", NULL, AT_SYMLINK_FOLLOW) > 0);
-        assert_se(path_is_mount_point("/dev/", NULL, 0) > 0);
-
         /* we'll create a hierarchy of different kinds of dir/file/link
          * layouts:
          *


### PR DESCRIPTION
Even /dev isn't always guaranteed to be a mount point, so let's drop this part of the test.

(cherry picked from commit bacad14f94a4e98c3e81d821c56dbe7e2e4726ff)

Related: RHEL-30372

<!-- issue-commentator = {"comment-id":"2165555171"} -->