### PR TITLE
(RHEL-30372) fuzz: pass -Dc_args=/-Dcpp_args= to fuzzer targets

### DIFF
--- a/test/fuzz/meson.build
+++ b/test/fuzz/meson.build
@@ -38,10 +38,11 @@ sanitize_address_undefined = custom_target(
                    project_source_root,
                    '@OUTPUT@',
                    'fuzzers',
-                   '-Dfuzz-tests=true -Db_lundef=false -Db_sanitize=address,undefined --optimization=@0@ @1@ -Dc_args=@2@ -Dcpp_args=@2@ -Dskip-deps=@3@'.format(
+                   ' '.join(get_option('c_args') + '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION'),
+                   ' '.join(get_option('cpp_args') + '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION'),
+                   '-Dfuzz-tests=true -Db_lundef=false -Db_sanitize=address,undefined --optimization=@0@ @1@ -Dskip-deps=@2@'.format(
                            get_option('optimization'),
                            get_option('werror') ? '--werror' : '',
-                           '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION',
                            get_option('skip-deps')
                    ),
                    ' '.join(cc.cmd_array()),

--- a/test/fuzz/meson.build
+++ b/test/fuzz/meson.build
@@ -31,6 +31,14 @@ endforeach
 
 ############################################################
 
+
+fuzz_c_args = get_option('c_args')
+if cxx_cmd != ''
+        fuzz_cpp_args = get_option('cpp_args')
+else
+        fuzz_cpp_args = []
+endif
+
 sanitize_address_undefined = custom_target(
         'sanitize-address-undefined-fuzzers',
         output : 'sanitize-address-undefined-fuzzers',
@@ -38,8 +46,8 @@ sanitize_address_undefined = custom_target(
                    project_source_root,
                    '@OUTPUT@',
                    'fuzzers',
-                   ' '.join(get_option('c_args') + '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION'),
-                   ' '.join(get_option('cpp_args') + '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION'),
+                   ' '.join(fuzz_c_args + ['-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION']),
+                   ' '.join(fuzz_cpp_args + ['-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION']),
                    '-Dfuzz-tests=true -Db_lundef=false -Db_sanitize=address,undefined --optimization=@0@ @1@ -Dskip-deps=@2@'.format(
                            get_option('optimization'),
                            get_option('werror') ? '--werror' : '',

--- a/test/fuzz/meson.build
+++ b/test/fuzz/meson.build
@@ -33,11 +33,7 @@ endforeach
 
 
 fuzz_c_args = get_option('c_args')
-if cxx_cmd != ''
-        fuzz_cpp_args = get_option('cpp_args')
-else
-        fuzz_cpp_args = []
-endif
+fuzz_cpp_args = cxx_cmd != '' ? get_option('cpp_args') : []
 
 sanitize_address_undefined = custom_target(
         'sanitize-address-undefined-fuzzers',

--- a/tools/meson-build.sh
+++ b/tools/meson-build.sh
@@ -10,7 +10,7 @@ CC="$5"
 CXX="$6"
 
 # shellcheck disable=SC2086
-[ -f "$dst/ninja.build" ] || CC="$CC" CXX="$CXX" meson "$src" "$dst" $options
+[ -f "$dst/build.ninja" ] || CC="$CC" CXX="$CXX" meson "$src" "$dst" $options
 
 # Locate ninja binary, on CentOS 7 it is called ninja-build, so
 # use that name if available.

--- a/tools/meson-build.sh
+++ b/tools/meson-build.sh
@@ -10,7 +10,7 @@ CC="$5"
 CXX="$6"
 
 # shellcheck disable=SC2086
-[ -f "$dst/build.ninja" ] || CC="$CC" CXX="$CXX" meson "$src" "$dst" $options
+[ -f "$dst/build.ninja" ] || CC="$CC" CXX="$CXX" meson setup "$src" "$dst" $options
 
 # Locate ninja binary, on CentOS 7 it is called ninja-build, so
 # use that name if available.

--- a/tools/meson-build.sh
+++ b/tools/meson-build.sh
@@ -9,7 +9,7 @@ c_args="${4:?}"
 cpp_args="${5:?}"
 options="${6:?}"
 CC="${7:?}"
-CXX="${8:?}"
+CXX="$8"
 
 if [ ! -f "$builddir/build.ninja" ]; then
     # shellcheck disable=SC2086

--- a/tools/meson-build.sh
+++ b/tools/meson-build.sh
@@ -2,21 +2,20 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -eux
 
-src="$1"
-dst="$2"
-target="$3"
-options="$4"
-CC="$5"
-CXX="$6"
+sourcedir="${1:?}"
+builddir="${2:?}"
+target="${3:?}"
+c_args="${4:?}"
+cpp_args="${5:?}"
+options="${6:?}"
+CC="${7:?}"
+CXX="${8:?}"
 
-# shellcheck disable=SC2086
-[ -f "$dst/build.ninja" ] || CC="$CC" CXX="$CXX" meson setup "$src" "$dst" $options
-
-# Locate ninja binary, on CentOS 7 it is called ninja-build, so
-# use that name if available.
-ninja="ninja"
-if command -v ninja-build >/dev/null ; then
-    ninja="ninja-build"
+if [ ! -f "$builddir/build.ninja" ]; then
+    # shellcheck disable=SC2086
+    CC="$CC" CXX="$CXX" meson setup -Dc_args="$c_args" -Dcpp_args="$cpp_args" "$builddir" "$sourcedir" $options
 fi
 
-"$ninja" -C "$dst" "$target"
+# Locate ninja binary, on CentOS 7 it is called ninja-build, so use that name if available.
+command -v ninja-build >/dev/null && ninja="ninja-build" || ninja="ninja"
+"$ninja" -C "$builddir" "$target"

--- a/tools/oss-fuzz.sh
+++ b/tools/oss-fuzz.sh
@@ -73,7 +73,7 @@ else
     fi
 fi
 
-if ! meson "$build" "-D$fuzzflag" -Db_lundef=false; then
+if ! meson setup "$build" "-D$fuzzflag" -Db_lundef=false; then
     cat "$build/meson-logs/meson-log.txt"
     exit 1
 fi


### PR DESCRIPTION
Prompted by #29972, because right now it's practically impossible to pass
-fno-sanitize=function to the fuzzer targets without some extensive
sed'ing.

This splits both c_args and cpp_args to separate arguments for
tools/meson-build.sh, because the other way would be to use `eval`, so
the space-separated but quoted strings passed to these options are not
split where they shouldn't, and I'd rather avoid using `eval` if
possible.

Also, this switches the positional arguments we pass to `meson setup`,
as they were in incorrect order (docs say it should be buildir followed
by sourcedir); meson is apparently clever enough to figure this out and
switch the arguments around if necessary, so it didn't complain.

(cherry picked from commit https://github.com/redhat-plumbers/systemd-rhel9/commit/17ee59c9c922553a8cb4d54cb8ae415706c4feff)

Related: RHEL-30372

---

Apart from the reason in the original commit, I need this for some internal shenanigans as well.

<!-- issue-commentator = {"comment-id":"2175676062"} -->