### PR TITLE
(RHEL-44630) netif-naming-scheme: make actually possible to use rhel-9.5 scheme

### DIFF
--- a/src/shared/netif-naming-scheme.c
+++ b/src/shared/netif-naming-scheme.c
@@ -44,6 +44,7 @@ static const NamingScheme naming_schemes[] = {
         { "rhel-9.2", NAMING_RHEL_9_2 },
         { "rhel-9.3", NAMING_RHEL_9_3 },
         { "rhel-9.4", NAMING_RHEL_9_4 },
+        { "rhel-9.5", NAMING_RHEL_9_5 },
         /* … add more schemes here, as the logic to name devices is updated … */
 
         EXTRA_NET_NAMING_MAP


### PR DESCRIPTION
In 753e1b1c9b255d528eb8b2a2af072a83eb85d784 we forgot to update the netif-naming-scheme.c file to allow people to actually use the new rhel-9.5 scheme.

RHEL-only

Resolves: RHEL-44630

<!-- issue-commentator = {"comment-id":"2206448110"} -->