### PR TITLE
(RHEL-33436) generator: "uninline" generator_open_unit_file and generator_add_symlink

### DIFF
--- a/src/shared/generator.c
+++ b/src/shared/generator.c
@@ -75,6 +75,10 @@ int generator_open_unit_file_full(
         return 0;
 }
 
+int generator_open_unit_file(const char *dest, const char *source, const char *name, FILE **ret_file) {
+        return generator_open_unit_file_full(dest, source, name, ret_file, NULL);
+}
+
 int generator_add_symlink_full(
                 const char *dir,
                 const char *dst,
@@ -123,6 +127,10 @@ int generator_add_symlink_full(
                 return log_error_errno(errno, "Failed to create symlink \"%s\": %m", to);
 
         return 0;
+}
+
+int generator_add_symlink(const char *dir, const char *dst, const char *dep_type, const char *src) {
+        return generator_add_symlink_full(dir, dst, dep_type, src, NULL);
 }
 
 static int generator_add_ordering(

--- a/src/shared/generator.h
+++ b/src/shared/generator.h
@@ -7,16 +7,10 @@
 #include "main-func.h"
 
 int generator_open_unit_file_full(const char *dest, const char *source, const char *name, FILE **ret_file, char **ret_temp_path);
-
-static inline int generator_open_unit_file(const char *dest, const char *source, const char *name, FILE **ret_file) {
-        return generator_open_unit_file_full(dest, source, name, ret_file, NULL);
-}
+int generator_open_unit_file(const char *dest, const char *source, const char *name, FILE **ret_file);
 
 int generator_add_symlink_full(const char *dir, const char *dst, const char *dep_type, const char *src, const char *instance);
-
-static inline int generator_add_symlink(const char *dir, const char *dst, const char *dep_type, const char *src) {
-        return generator_add_symlink_full(dir, dst, dep_type, src, NULL);
-}
+int generator_add_symlink(const char *dir, const char *dst, const char *dep_type, const char *src);
 
 int generator_write_fsck_deps(
         FILE *f,


### PR DESCRIPTION
Inlining of these functions changed ABI of libsystemd-shared which causes issue on update when generators packaged in systemd-udev subpackage fail to execute because of ABI change. systemd and the library are already updated while systemd-udev subpackage is not and hence old generators can't be started when systemd is reexecuting due to internal library incompatibility.

rhel-only: bugfix

Resolves: RHEL-33436

<!-- issue-commentator = {"comment-id":"2231376234"} -->