### PR TITLE
(RHEL-49495) generator: "uninline" generator_open_unit_file and generator_add_symlink

### DIFF
--- a/src/shared/generator.c
+++ b/src/shared/generator.c
@@ -109,6 +109,10 @@ int generator_add_symlink_full(
         return 0;
 }
 
+int generator_add_symlink(const char *dir, const char *dst, const char *dep_type, const char *src) {
+        return generator_add_symlink_full(dir, dst, dep_type, src, NULL);
+}
+
 static int generator_add_ordering(
                 const char *dir,
                 const char *src,

--- a/src/shared/generator.h
+++ b/src/shared/generator.h
@@ -13,10 +13,7 @@ int generator_open_unit_file(
         FILE **file);
 
 int generator_add_symlink_full(const char *dir, const char *dst, const char *dep_type, const char *src, const char *instance);
-
-static inline int generator_add_symlink(const char *dir, const char *dst, const char *dep_type, const char *src) {
-        return generator_add_symlink_full(dir, dst, dep_type, src, NULL);
-}
+int generator_add_symlink(const char *dir, const char *dst, const char *dep_type, const char *src);
 
 int generator_write_fsck_deps(
         FILE *f,


### PR DESCRIPTION
Inlining of these functions changed ABI of libsystemd-shared which causes issue on update when generators packaged in systemd-udev subpackage fail to execute because of ABI change. systemd and the library are already updated while systemd-udev subpackage is not and hence old generators can't be started when systemd is reexecuting due to internal library incompatibility.

rhel-only: bugfix

Resolves: RHEL-49495

<!-- issue-commentator = {"comment-id":"2233350589"} -->