### PR TITLE
(RHEL-45020) timedatectl: setting set_local_rtc to 1 will throw Warning as well, u…

### DIFF
--- a/src/timedate/timedatectl.c
+++ b/src/timedate/timedatectl.c
@@ -152,14 +152,15 @@ static int print_status_info(const StatusInfo *i) {
         if (r < 0)
                 return table_log_print_error(r);
 
-        if (i->rtc_local)
-                printf("\n%s"
-                       "Warning: The system is configured to read the RTC time in the local time zone.\n"
-                       "         This mode cannot be fully supported. It will create various problems\n"
-                       "         with time zone changes and daylight saving time adjustments. The RTC\n"
-                       "         time is never updated, it relies on external facilities to maintain it.\n"
-                       "         If at all possible, use RTC in UTC by calling\n"
-                       "         'timedatectl set-local-rtc 0'.%s\n", ansi_highlight(), ansi_normal());
+        if (i->rtc_local) {
+                fflush(stdout);
+                log_warning(" \nWarning: The system is configured to read the RTC time in the local time zone.\n"
+                            "         This mode cannot be fully supported. It will create various problems\n"
+                            "         with time zone changes and daylight saving time adjustments. The RTC\n"
+                            "         time is never updated, it relies on external facilities to maintain it.\n"
+                            "         If at all possible, use RTC in UTC by calling\n"
+                            "         'timedatectl set-local-rtc 0'.\n");
+        }
 
         return 0;
 }
@@ -263,6 +264,13 @@ static int set_local_rtc(int argc, char **argv, void *userdata) {
         b = parse_boolean(argv[1]);
         if (b < 0)
                 return log_error_errno(b, "Failed to parse local RTC setting '%s': %m", argv[1]);
+
+        if (b == 1)
+                log_warning("Warning: The system is now being configured to read the RTC time in the local time zone\n"
+                            "         This mode cannot be fully supported. It will create various problems\n"
+                            "         with time zone changes and daylight saving time adjustments. The RTC\n"
+                            "         time is never updated, it relies on external facilities to maintain it.\n"
+                            "         If at all possible, use RTC in UTC");
 
         r = bus_call_method(
                         bus,


### PR DESCRIPTION
…se log_warning() (#33489)

Previously only running `timedatectl` it was showing warning regarding the dangers of setting RTC to local TZ.
Now similar warning is also flashed when `set-local-rtc 1`.

(cherry picked from commit db708fc9ba551325e000cc12bd3490a5de0715ba)

Resolves: RHEL-45020

<!-- issue-commentator = {"comment-id":"2242602033"} -->