### PR TITLE
(RHEL-50672) Harden /bin/kernel-install to avoid failing silently when /etc/machine-id doesn't end with newline

### DIFF
--- a/src/kernel-install/kernel-install.in
+++ b/src/kernel-install/kernel-install.in
@@ -159,7 +159,7 @@ if [ -z "$MACHINE_ID" ] && [ -f /etc/machine-info ]; then
         log_verbose "machine-id $MACHINE_ID acquired from /etc/machine-info"
 fi
 if [ -z "$MACHINE_ID" ] && [ -s /etc/machine-id ]; then
-    read -r MACHINE_ID </etc/machine-id
+    read -r MACHINE_ID </etc/machine-id || :
     if [ "$MACHINE_ID" = "uninitialized" ]; then
         unset MACHINE_ID
     elif [ {{ '${#MACHINE_ID}' }} -ne 32 ]; then

--- a/src/kernel-install/kernel-install.in
+++ b/src/kernel-install/kernel-install.in
@@ -160,7 +160,12 @@ if [ -z "$MACHINE_ID" ] && [ -f /etc/machine-info ]; then
 fi
 if [ -z "$MACHINE_ID" ] && [ -s /etc/machine-id ]; then
     read -r MACHINE_ID </etc/machine-id
-    [ "$MACHINE_ID" = "uninitialized" ] && unset MACHINE_ID
+    if [ "$MACHINE_ID" = "uninitialized" ]; then
+        unset MACHINE_ID
+    elif [ {{ '${#MACHINE_ID}' }} -ne 32 ]; then
+        echo "Error: invalid machine-id $MACHINE_ID read from /etc/machine-id" >&2
+        exit 1
+    fi
     [ -n "$MACHINE_ID" ] && \
         log_verbose "machine-id $MACHINE_ID acquired from /etc/machine-id"
 fi


### PR DESCRIPTION
Resolves: RHEL-50672

<!-- issue-commentator = {"comment-id":"2260659806"} -->