### PR TITLE
(RHEL-59088) udev: Handle PTP device symlink properly on udev action 'change'

### DIFF
--- a/rules.d/50-udev-default.rules.in
+++ b/rules.d/50-udev-default.rules.in
@@ -21,6 +21,9 @@ ENV{MODALIAS}!="", IMPORT{builtin}="hwdb --subsystem=$env{SUBSYSTEM}"
 
 SUBSYSTEM=="net", IMPORT{builtin}="net_driver"
 
+SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK+="ptp_kvm"
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK+="ptp_hyperv"
+
 ACTION!="add", GOTO="default_end"
 
 SUBSYSTEM=="tty", KERNEL=="ptmx", GROUP="tty", MODE="0666"
@@ -108,10 +111,6 @@ KERNEL=="vhost-vsock", GROUP="kvm", MODE="{{DEV_KVM_MODE}}", OPTIONS+="static_no
 KERNEL=="vhost-net", GROUP="kvm", MODE="{{DEV_KVM_MODE}}", OPTIONS+="static_node=vhost-net"
 
 KERNEL=="udmabuf", GROUP="kvm"
-
-SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
-
-SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"
 
 SUBSYSTEM!="dmi", GOTO="dmi_end"
 ENV{ID_SYS_VENDOR_IS_RUBBISH}!="1", ENV{ID_VENDOR}="$attr{sys_vendor}"


### PR DESCRIPTION
PTP device symlink creation rules are currently executed only when the udev action is 'add'. If a user reloads the rules and runs the udevadm trigger command to reapply changes, the symlink may be deleted, which can prevent the chronyd service from restarting properly.

Signed-off-by: Chengen Du <chengen.du@canonical.com>
(cherry picked from commit 6bd12be3fa7761f190e17efdbdbff4440da7528b)

Resolves: RHEL-59088

<!-- issue-commentator = {"comment-id":"2370667620"} -->