### PR TITLE
(RHEL-36531) man: using WantedBy=default.target is not a good idea

### DIFF
--- a/man/systemd.special.xml
+++ b/man/systemd.special.xml
@@ -229,6 +229,11 @@
             names like <varname>single</varname>, <varname>rescue</varname>, <varname>1</varname>,
             <varname>3</varname>, <varname>5</varname>, …; see
             <citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry>.</para>
+
+            <para>For typical unit files please set <literal>WantedBy=</literal> to a regular target (like
+            <filename>multi-user.target</filename> or <filename>graphical.target</filename>),
+            instead of <filename>default.target</filename>, since such a service will also be run on special
+            boots like on system update, emergency boot…</para>
           </listitem>
         </varlistentry>
         <varlistentry>


### PR DESCRIPTION
We had several users, that wrote their unit files with WantedBy=default.target because it should be started "every time". But for example in Fedora/CentOS/RHEL, this often breaks for example selinux relabels (where we just want to do a relabel and reboot).

(cherry picked from commit 67b6404b80cf8078f3d9ec6d4c2f34ac25b15077)

Resolves: RHEL-36531

<!-- issue-commentator = {"comment-id":"2391063717"} -->