### PR TITLE
(RHEL-24340) logind: tighten for which classes of sessions we do stop-on-idle

### DIFF
--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -735,7 +735,7 @@ static int session_setup_stop_on_idle_timer(Session *s) {
 
         assert(s);
 
-        if (s->manager->stop_idle_session_usec == USEC_INFINITY || IN_SET(s->class, SESSION_GREETER, SESSION_LOCK_SCREEN))
+        if (s->manager->stop_idle_session_usec == USEC_INFINITY || !SESSION_CLASS_CAN_STOP_ON_IDLE(s->class))
                 return 0;
 
         r = sd_event_add_time_relative(

--- a/src/login/logind-session.h
+++ b/src/login/logind-session.h
@@ -27,6 +27,9 @@ typedef enum SessionClass {
         _SESSION_CLASS_INVALID = -EINVAL,
 } SessionClass;
 
+/* Which sessions classes should be subject to stop-in-idle */
+#define SESSION_CLASS_CAN_STOP_ON_IDLE(class) (IN_SET((class), SESSION_USER))
+
 typedef enum SessionType {
         SESSION_UNSPECIFIED,
         SESSION_TTY,


### PR DESCRIPTION
We only want to do this for fully set up, interactive sessions, i.e. user and user-early, but not for any others, hence restrict the rules a bit.

Follow-up for: 508b4786e8592e82eb4832549f74aaa54335d14c

(cherry picked from commit ad23439eae718ac3634f260be0d29e01445983a8)

Related: RHEL-24340

<!-- issue-commentator = {"comment-id":"2486186379"} -->