### PR TITLE
(RHEL-5956) install: don't translate unit instances to paths when reenabling them

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -2875,7 +2875,7 @@ static int normalize_linked_files(
                         return log_debug_errno(SYNTHETIC_ERRNO(EISDIR),
                                                "Unexpected path to a directory \"%s\", refusing.", *a);
 
-                if (!is_path(*a)) {
+                if (!is_path(*a) && !unit_name_is_valid(*a, UNIT_NAME_INSTANCE)) {
                         r = install_info_discover(&ctx, lp, n, SEARCH_LOAD|SEARCH_FOLLOW_CONFIG_SYMLINKS, &i, NULL, NULL);
                         if (r < 0)
                                 log_debug_errno(r, "Failed to discover unit \"%s\", operating on name: %m", n);

--- a/test/test-systemctl-enable.sh
+++ b/test/test-systemctl-enable.sh
@@ -97,7 +97,7 @@ test ! -e "$root/etc/systemd/system/test1-badalias.target"
 test ! -e "$root/etc/systemd/system/test1-badalias.socket"
 test -h "$root/etc/systemd/system/test1-goodalias2.service"
 
-: '-------aliases in reeanable----------------------------------'
+: '-------aliases in reenable----------------------------------'
 ( ! "$systemctl" --root="$root" reenable test1 )
 test -h "$root/etc/systemd/system/default.target.wants/test1.service"
 test ! -e "$root/etc/systemd/system/test1-goodalias.service"


### PR DESCRIPTION
For unit instances install_info_discover() returns path to the template, which then generates confusing errors when passed to do_unit_file_enable():

~# build/systemctl --root=/tmp/systemctl-test.N9ysbz reenable templ1@two.service Unit name: templ1@two.service; p: /etc/systemd/system/templ1@.service Removed "/tmp/systemctl-test.N9ysbz/etc/systemd/system/services.target.wants/templ1@two.service". Failed to reenable templ1@.service, destination unit services.target is a non-template unit.

This can also be seen with a different reproducer using getty@.service and a simple bind mount to / - there's no error this time, but it tries to create a symlink for the default instance (from DefaultInstance=tty1), which is also incorrect:

~# SYSTEMD_LOG_LEVEL=debug systemctl --root /mnt/bindroot/ reenable getty@test.service Symlink /mnt/bindroot/etc/systemd/system/getty.target.wants/getty@tty1.service → /usr/lib/systemd/system/getty@.service already exists

Follow-up to: 29a7c59abbe
Resolves upstream issue #24740

(cherry picked from commit fe6e0cfa19dd1de4ac599ae207182fd556adcfa7)

Resolves: RHEL-5956

<!-- issue-commentator = {"comment-id":"2556965951"} -->