### PR TITLE
(RHEL-70884) ci: use ubuntu 22:04 for deploy of man pages

### DIFF
--- a/.github/workflows/deploy-man-pages.yml
+++ b/.github/workflows/deploy-man-pages.yml
@@ -26,7 +26,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       pages: write


### PR DESCRIPTION
rhel-only: ci

Related: RHEL-70884

<!-- issue-commentator = {"comment-id":"2589924711"} -->