### PR TITLE
(RHEL-15051) man: be even clearer that tmpfiles user/group/mode are applied on exi…

### DIFF
--- a/man/tmpfiles.d.xml
+++ b/man/tmpfiles.d.xml
@@ -546,9 +546,10 @@ w- /proc/sys/vm/swappiness - - - - 10</programlisting></para>
       removed unless applied to a directory. This functionality is particularly useful in conjunction with
       <varname>Z</varname>.</para>
 
-      <para>Optionally, if prefixed with <literal>:</literal>, the configured access mode is only used when
-      creating new inodes. If the inode the line refers to already exists, its access mode is left in place
-      unmodified.</para>
+      <para>By default the access mode of listed inodes is set to the specified mode regardless if it is
+      created anew, or already existed. Optionally, if prefixed with <literal>:</literal>, the configured
+      access mode is only applied when creating new inodes, and if the inode the line refers to
+      already exists, its access mode is left in place unmodified.</para>
     </refsect2>
 
     <refsect2>
@@ -569,9 +570,10 @@ w- /proc/sys/vm/swappiness - - - - 10</programlisting></para>
       Resolvability of User and Group Names</ulink> for more information on requirements on system user/group
       definitions.</para>
 
-      <para>Optionally, if prefixed with <literal>:</literal>, the configured user/group information is only
-      used when creating new inodes. If the inode the line refers to already exists, its user/group is left
-      in place unmodified.</para>
+      <para>By default the ownership of listed inodes is set to the specified user/group regardless if it is
+      created anew, or already existed. Optionally, if prefixed with <literal>:</literal>, the configured
+      user/group information is only applied when creating new inodes, and if the inode the line refers to
+      already exists, its user/group is left in place unmodified.</para>
     </refsect2>
 
     <refsect2>


### PR DESCRIPTION
…sting inodes

I think it was clear already, but let's be even clearer.

Fixes: #29774
(cherry picked from commit 3cb938bd12b3603984b982e9b73e4cabd4a608e3)

Resolves: RHEL-15051

<!-- issue-commentator = {"comment-id":"2626705194"} -->