### PR TITLE
coredump: check mnt ns equality to decide if we shall change our mnt ns.

### DIFF
--- a/src/coredump/coredump.c
+++ b/src/coredump/coredump.c
@@ -1478,9 +1478,9 @@ static int process_kernel(int argc, char* argv[]) {
                 log_open();
         }
 
-        r = in_same_namespace(getpid_cached(), context.pid, NAMESPACE_PID);
+        r = in_same_namespace(getpid_cached(), context.pid, NAMESPACE_MOUNT);
         if (r < 0)
-                log_debug_errno(r, "Failed to check pidns of crashing process, ignoring: %m");
+                log_debug_errno(r, "Failed to check mntns of crashing process, ignoring: %m");
 
         if (r == 0 && getenv_bool("SYSTEMD_COREDUMP_ALLOW_NAMESPACE_CHANGE") > 0) {
                 r = namespace_open(context.pid,  NULL, &mntns_fd, NULL, NULL, NULL);


### PR DESCRIPTION
Indeed there is no reason that the pid namespace is not shared with thehost in a container. However by definition the mount namespace isn't shared. Typically in OpenShift, when we "oc debug" a node, we get a new container (so a dedicated mount namespace) but this container shares the host pid namespace. Core dumps happening in such a container have a wrong backtrace reported by systemd-coredumper as it doesn't even try to change its mount namspace while it should.

Thus it seems more correct to compare mount namspaces rather than pid namespaces.

@msekletar This is related to our call from last week and the Red Hat case I will send you by mail.

<!-- issue-commentator = {"comment-id":"2723298193"} -->