### PR TITLE
(RHEL-79977) ci: enable mkosi workflow for z-stream branches

### DIFF
--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -83,6 +83,7 @@ jobs:
         [Host]
         ToolsTree=default
         ToolsTreeDistribution=fedora
+        ToolsTreeRelease=41
         # Sometimes we run on a host with /dev/kvm, but it is broken, so explicitly disable it
         QemuKvm=no
         EOF


### PR DESCRIPTION
rhel-only: ci

Related: RHEL-79977

<!-- issue-commentator = {"comment-id":"2783268230"} -->