### PR TITLE
(RHEL-86237) unit: always return 1 in log_kill

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -4532,7 +4532,9 @@ static int log_kill(pid_t pid, int sig, void *userdata) {
         /* Don't log about processes marked with brackets, under the assumption that these are temporary processes
            only, like for example systemd's own PAM stub process. */
         if (comm && comm[0] == '(')
-                return 0;
+                /* Although we didn't log anything, as this callback is used in unit_kill_context we must return 1
+                 * here to let the manager know that a process was killed. */
+                return 1;
 
         log_unit_notice(userdata,
                         "Killing process " PID_FMT " (%s) with signal SIG%s.",


### PR DESCRIPTION
This ensures that cg_kill_items returns the correct value to let the manager know that a process was killed.

(cherry picked from commit 500cd2e83b8246fbf20d99db898039cfba746223)

Resolves: RHEL-86237