### PR TITLE
creds-util: drop unnecessary include

### DIFF
--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -27,7 +27,6 @@
 #include "sparse-endian.h"
 #include "stat-util.h"
 #include "tpm2-util.h"
-#include "virt.h"
 
 #define PUBLIC_KEY_MAX (UINT32_C(1024) * UINT32_C(1024))
 


### PR DESCRIPTION
Follow-up for: e653a194e490fae7d166f40762c334006d592051

(cherry picked from commit a9e4057f1f49ab3d10a32d898b904c4ccfeeb41e)

Resolves: RHEL-108559