### PR TITLE
(RHEL-109096) meson: /etc/systemd/network is also used by udevd

### DIFF
--- a/network/meson.build
+++ b/network/meson.build
@@ -12,11 +12,12 @@ if conf.get('ENABLE_NETWORKD') == 1
                      '80-wifi-station.network.example',
                      install_dir : networkdir)
 
-        if install_sysconfdir
-                meson.add_install_script('sh', '-c',
-                                         mkdir_p.format(sysconfdir / 'systemd/network'))
-        endif
 endif
 
 install_data('99-default.link',
              install_dir : networkdir)
+
+if install_sysconfdir
+        meson.add_install_script('sh', '-c',
+                                 mkdir_p.format(sysconfdir / 'systemd/network'))
+endif


### PR DESCRIPTION
(cherry picked from commit 6256c65aad2a719ac9054961561bb26e497208ce)

Resolves: RHEL-109096

<!-- issue-commentator = {"comment-id":"3220048732"} -->