### PR TITLE
(RHEL-108587) compress: replace compress_blob() with compress_blob_explicit()

### DIFF
--- a/src/basic/compress.c
+++ b/src/basic/compress.c
@@ -108,7 +108,7 @@ int compress_blob_xz(const void *src, uint64_t src_size,
                 return -ENOBUFS;
 
         *dst_size = out_pos;
-        return COMPRESSION_XZ;
+        return 0;
 #else
         return -EPROTONOSUPPORT;
 #endif
@@ -138,7 +138,7 @@ int compress_blob_lz4(const void *src, uint64_t src_size,
         unaligned_write_le64(dst, src_size);
         *dst_size = r + 8;
 
-        return COMPRESSION_LZ4;
+        return 0;
 #else
         return -EPROTONOSUPPORT;
 #endif
@@ -161,7 +161,7 @@ int compress_blob_zstd(
                 return zstd_ret_to_errno(k);
 
         *dst_size = k;
-        return COMPRESSION_ZSTD;
+        return 0;
 #else
         return -EPROTONOSUPPORT;
 #endif
@@ -627,7 +627,7 @@ int compress_stream_xz(int fdf, int fdt, uint64_t max_bytes, uint64_t *ret_uncom
                                           s.total_in, s.total_out,
                                           (double) s.total_out / s.total_in * 100);
 
-                                return COMPRESSION_XZ;
+                                return 0;
                         }
                 }
         }
@@ -718,7 +718,7 @@ int compress_stream_lz4(int fdf, int fdt, uint64_t max_bytes, uint64_t *ret_unco
                   total_in, total_out,
                   (double) total_out / total_in * 100);
 
-        return COMPRESSION_LZ4;
+        return 0;
 #else
         return -EPROTONOSUPPORT;
 #endif
@@ -962,7 +962,7 @@ int compress_stream_zstd(int fdf, int fdt, uint64_t max_bytes, uint64_t *ret_unc
                 log_debug("ZSTD compression finished (%" PRIu64 " -> %" PRIu64 " bytes)",
                           in_bytes, max_bytes - left);
 
-        return COMPRESSION_ZSTD;
+        return 0;
 #else
         return -EPROTONOSUPPORT;
 #endif

--- a/src/basic/compress.h
+++ b/src/basic/compress.h
@@ -63,7 +63,7 @@ int decompress_stream_xz(int fdf, int fdt, uint64_t max_size);
 int decompress_stream_lz4(int fdf, int fdt, uint64_t max_size);
 int decompress_stream_zstd(int fdf, int fdt, uint64_t max_size);
 
-static inline int compress_blob_explicit(
+static inline int compress_blob(
                 Compression compression,
                 const void *src, uint64_t src_size,
                 void *dst, size_t dst_alloc_size, size_t *dst_size) {
@@ -79,12 +79,6 @@ static inline int compress_blob_explicit(
                 return -EOPNOTSUPP;
         }
 }
-
-#define compress_blob(src, src_size, dst, dst_alloc_size, dst_size) \
-        compress_blob_explicit(                                     \
-                DEFAULT_COMPRESSION,                                \
-                src, src_size,                                      \
-                dst, dst_alloc_size, dst_size)
 
 static inline int compress_stream(int fdf, int fdt, uint64_t max_bytes, uint64_t *ret_uncompressed_size) {
         switch (DEFAULT_COMPRESSION) {

--- a/src/fuzz/fuzz-compress.c
+++ b/src/fuzz/fuzz-compress.c
@@ -45,7 +45,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         }
 
         size_t csize;
-        r = compress_blob_explicit(alg, h->data, data_len, buf, size, &csize);
+        r = compress_blob(alg, h->data, data_len, buf, size, &csize);
         if (r < 0) {
                 log_error_errno(r, "Compression failed: %m");
                 return 0;

--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -1635,7 +1635,7 @@ static int journal_file_append_field(
         return 0;
 }
 
-static Compression maybe_compress_payload(JournalFile *f, uint8_t *dst, const uint8_t *src, uint64_t size, size_t *rsize) {
+static int maybe_compress_payload(JournalFile *f, uint8_t *dst, const uint8_t *src, uint64_t size, size_t *rsize) {
         assert(f);
         assert(f->header);
 
@@ -1645,21 +1645,17 @@ static Compression maybe_compress_payload(JournalFile *f, uint8_t *dst, const ui
 
         c = JOURNAL_FILE_COMPRESSION(f);
         if (c == COMPRESSION_NONE || size < f->compress_threshold_bytes)
-                return COMPRESSION_NONE;
+                return 0;
 
-        r = compress_blob_explicit(c, src, size, dst, size - 1, rsize);
-        if (r < 0) {
-                log_debug_errno(r, "Failed to compress data object using %s, ignoring: %m", compression_to_string(c));
-                /* Compression didn't work, we don't really care why, let's continue without compression */
-                return COMPRESSION_NONE;
-        }
+        r = compress_blob(c, src, size, dst, size - 1, rsize);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to compress data object using %s, ignoring: %m", compression_to_string(c));
 
-        assert(r == c);
         log_debug("Compressed data object %"PRIu64" -> %zu using %s", size, *rsize, compression_to_string(c));
 
-        return c;
+        return 1; /* compressed */
 #else
-        return COMPRESSION_NONE;
+        return 0;
 #endif
 }
 
@@ -1673,7 +1669,6 @@ static int journal_file_append_data(
         uint64_t hash, p, osize;
         Object *o, *fo;
         size_t rsize = 0;
-        Compression c;
         const void *eq;
         int r;
 
@@ -1701,13 +1696,18 @@ static int journal_file_append_data(
 
         o->data.hash = htole64(hash);
 
-        c = maybe_compress_payload(f, journal_file_data_payload_field(f, o), data, size, &rsize);
+        r = maybe_compress_payload(f, journal_file_data_payload_field(f, o), data, size, &rsize);
+        if (r <= 0)
+                /* We don't really care failures, let's continue without compression */
+                memcpy_safe(journal_file_data_payload_field(f, o), data, size);
+        else {
+                Compression c = JOURNAL_FILE_COMPRESSION(f);
 
-        if (c != COMPRESSION_NONE) {
+                assert(c >= 0 && c < _COMPRESSION_MAX && c != COMPRESSION_NONE);
+
                 o->object.size = htole64(journal_file_data_payload_offset(f) + rsize);
                 o->object.flags |= COMPRESSION_TO_OBJECT_FLAG(c);
-        } else
-                memcpy_safe(journal_file_data_payload_field(f, o), data, size);
+        }
 
         r = journal_file_link_data(f, o, p, hash);
         if (r < 0)

--- a/src/test/test-compress-benchmark.c
+++ b/src/test/test-compress-benchmark.c
@@ -102,7 +102,7 @@ static void test_compress_decompress(const char* label, const char* type,
 
                 r = compress(text, size, buf, size, &j);
                 /* assume compression must be successful except for small or random inputs */
-                assert_se(r > 0 || (size < 2048 && r == -ENOBUFS) || streq(type, "random"));
+                assert_se(r >= 0 || (size < 2048 && r == -ENOBUFS) || streq(type, "random"));
 
                 /* check for overwrites */
                 assert_se(buf[size] == 0);


### PR DESCRIPTION
And make compress_xyz() return 0 on success, as we know which compression algorithm is used when calling compress_blob().

Follow-up for 2360352ef02548723ac0c8eaf5ff6905eb9eeca5.

(cherry picked from commit bfeaa62dbc9d2a436e2d3413386ba38f48b5d502)

Resolves: RHEL-108587

<!-- issue-commentator = {"comment-id":"3233300488"} -->