### PR TITLE
(RHEL-108584) Backport follow-ups for - core/mount: escape invalid UTF8 char in dbus reply

### DIFF
--- a/src/core/dbus-mount.c
+++ b/src/core/dbus-mount.c
@@ -11,6 +11,27 @@
 #include "unit.h"
 #include "utf8.h"
 
+static int property_get_where(
+                sd_bus *bus,
+                const char *path,
+                const char *interface,
+                const char *property,
+                sd_bus_message *reply,
+                void *userdata,
+                sd_bus_error *error) {
+
+        Mount *m = ASSERT_PTR(userdata);
+
+        assert(bus);
+        assert(reply);
+
+        _cleanup_free_ char *escaped = mount_get_where_escaped(m);
+        if (!escaped)
+                return -ENOMEM;
+
+        return sd_bus_message_append_basic(reply, 's', escaped);
+}
+
 static int property_get_what(
                 sd_bus *bus,
                 const char *path,
@@ -84,7 +105,7 @@ static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_result, mount_result, MountResu
 
 const sd_bus_vtable bus_mount_vtable[] = {
         SD_BUS_VTABLE_START(0),
-        SD_BUS_PROPERTY("Where", "s", NULL, offsetof(Mount, where), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("Where", "s", property_get_where, 0, SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("What", "s", property_get_what, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
         SD_BUS_PROPERTY("Options","s", property_get_options, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
         SD_BUS_PROPERTY("Type", "s", property_get_type, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),

--- a/src/core/mount.h
+++ b/src/core/mount.h
@@ -93,6 +93,8 @@ extern const UnitVTable mount_vtable;
 
 void mount_fd_event(Manager *m, int events);
 
+char* mount_get_where_escaped(const Mount *m);
+
 const char* mount_exec_command_to_string(MountExecCommand i) _const_;
 MountExecCommand mount_exec_command_from_string(const char *s) _pure_;
 

--- a/src/libsystemd/sd-bus/bus-message.c
+++ b/src/libsystemd/sd-bus/bus-message.c
@@ -1324,10 +1324,19 @@ int message_append_basic(sd_bus_message *m, char type, const void *p, const void
                  * into the empty string */
                 p = strempty(p);
 
-                _fallthrough_;
+                if (!utf8_is_valid(p))
+                        return -EINVAL;
+
+                align = 4;
+                sz = 4 + strlen(p) + 1;
+                break;
+
         case SD_BUS_TYPE_OBJECT_PATH:
 
                 if (!p)
+                        return -EINVAL;
+
+                if (!object_path_is_valid(p))
                         return -EINVAL;
 
                 align = 4;
@@ -1337,6 +1346,9 @@ int message_append_basic(sd_bus_message *m, char type, const void *p, const void
         case SD_BUS_TYPE_SIGNATURE:
 
                 p = strempty(p);
+
+                if (!signature_is_valid(p, /* allow_dict_entry = */ true))
+                        return -EINVAL;
 
                 align = 1;
                 sz = 1 + strlen(p) + 1;

--- a/test/units/testsuite-07.mount-invalid-chars.sh
+++ b/test/units/testsuite-07.mount-invalid-chars.sh
@@ -23,7 +23,7 @@ TMP_MOUNTINFO="$(mktemp)"
 
 cp /proc/1/mountinfo "$TMP_MOUNTINFO"
 # Add a mount entry with a "Unicode non-character" in it
-echo -ne '69 1 252:2 / /foo/mountinfo rw,relatime shared:1 - cifs //foo\ufffebar rw,seclabel\n' >>"$TMP_MOUNTINFO"
+LANG="C.UTF-8" printf '69 1 252:2 / /foo/mountinfo rw,relatime shared:1 - cifs //foo\ufffebar rw,seclabel\n' >>"$TMP_MOUNTINFO"
 mount --bind "$TMP_MOUNTINFO" /proc/1/mountinfo
 systemctl daemon-reload
 # On affected versions this would throw an error:
@@ -42,12 +42,12 @@ rm -f "$TMP_MOUNTINFO"
 # a) Unit generated from /etc/fstab
 [[ -e /etc/fstab ]] && cp -f /etc/fstab /tmp/fstab.bak
 
-echo -ne '//localhost/foo\ufffebar  /foo/fstab  cifs defaults 0 0\n' >/etc/fstab
+LANG="C.UTF-8" printf '//localhost/foo\ufffebar  /foo/fstab  cifs defaults 0 0\n' >/etc/fstab
 systemctl daemon-reload
 [[ "$(systemctl show -P UnitFileState foo-fstab.mount)" == bad ]]
 
 # b) Unit generated from /etc/fstab (but the invalid character is in options)
-echo -ne '//localhost/foobar  /foo/fstab/opt  cifs nosuid,a\ufffeb,noexec 0 0\n' >/etc/fstab
+LANG="C.UTF-8" printf '//localhost/foobar  /foo/fstab/opt  cifs nosuid,a\ufffeb,noexec 0 0\n' >/etc/fstab
 systemctl daemon-reload
 [[ "$(systemctl show -P UnitFileState foo-fstab-opt.mount)" == bad ]]
 rm -f /etc/fstab
@@ -57,14 +57,14 @@ systemctl daemon-reload
 
 # c) Mount unit
 mkdir -p /run/systemd/system
-echo -ne '[Mount]\nWhat=//localhost/foo\ufffebar\nWhere=/foo/unit\nType=cifs\nOptions=noexec\n' >/run/systemd/system/foo-unit.mount
+LANG="C.UTF-8" printf '[Mount]\nWhat=//localhost/foo\ufffebar\nWhere=/foo/unit\nType=cifs\nOptions=noexec\n' >/run/systemd/system/foo-unit.mount
 systemctl daemon-reload
 [[ "$(systemctl show -P UnitFileState foo-unit.mount)" == bad ]]
 rm -f /run/systemd/system/foo-unit.mount
 
 # d) Mount unit (but the invalid character is in Options=)
 mkdir -p /run/systemd/system
-echo -ne '[Mount]\nWhat=//localhost/foobar\nWhere=/foo/unit/opt\nType=cifs\nOptions=noexec,a\ufffeb,nosuid\n' >/run/systemd/system/foo-unit-opt.mount
+LANG="C.UTF-8" printf '[Mount]\nWhat=//localhost/foobar\nWhere=/foo/unit/opt\nType=cifs\nOptions=noexec,a\ufffeb,nosuid\n' >/run/systemd/system/foo-unit-opt.mount
 systemctl daemon-reload
 [[ "$(systemctl show -P UnitFileState foo-unit-opt.mount)" == bad ]]
 rm -f /run/systemd/system/foo-unit-opt.mount

--- a/test/units/testsuite-07.mount-invalid-chars.sh
+++ b/test/units/testsuite-07.mount-invalid-chars.sh
@@ -23,12 +23,13 @@ TMP_MOUNTINFO="$(mktemp)"
 
 cp /proc/1/mountinfo "$TMP_MOUNTINFO"
 # Add a mount entry with a "Unicode non-character" in it
-LANG="C.UTF-8" printf '69 1 252:2 / /foo/mountinfo rw,relatime shared:1 - cifs //foo\ufffebar rw,seclabel\n' >>"$TMP_MOUNTINFO"
+LANG="C.UTF-8" printf '69 1 252:2 / /foo/mount\ufffeinfo rw,relatime shared:1 - cifs //foo\ufffebar rw,seclabel\n' >>"$TMP_MOUNTINFO"
 mount --bind "$TMP_MOUNTINFO" /proc/1/mountinfo
 systemctl daemon-reload
 # On affected versions this would throw an error:
 #   Failed to get properties: Bad message
-systemctl status foo-mountinfo.mount
+systemctl list-units -t mount
+systemctl status foo-mount\\xef\\xbf\\xbeinfo.mount
 
 umount /proc/1/mountinfo
 systemctl daemon-reload

--- a/test/units/testsuite-07.mount-invalid-chars.sh
+++ b/test/units/testsuite-07.mount-invalid-chars.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 at_exit() {
     mountpoint -q /proc/1/mountinfo && umount /proc/1/mountinfo
-    [[ -e /tmp/fstab.bak ]] && mv -f /tmp/fstab /etc/fstab
+    [[ -e /tmp/fstab.bak ]] && mv -f /tmp/fstab.bak /etc/fstab
     rm -f /run/systemd/system/foo-*.mount
     systemctl daemon-reload
 }

--- a/test/units/testsuite-07.mount-invalid-chars.sh
+++ b/test/units/testsuite-07.mount-invalid-chars.sh
@@ -52,7 +52,7 @@ systemctl daemon-reload
 [[ "$(systemctl show -P UnitFileState foo-fstab-opt.mount)" == bad ]]
 rm -f /etc/fstab
 
-[[ -e /tmp/fstab.bak ]] && mv -f /tmp/fstab /etc/fstab
+[[ -e /tmp/fstab.bak ]] && mv -f /tmp/fstab.bak /etc/fstab
 systemctl daemon-reload
 
 # c) Mount unit

--- a/test/units/testsuite-07.mount-invalid-chars.sh
+++ b/test/units/testsuite-07.mount-invalid-chars.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -eux
+set -o pipefail
+
+# Don't send invalid characters over dbus if a mount contains them
+
+at_exit() {
+    mountpoint -q /proc/1/mountinfo && umount /proc/1/mountinfo
+    [[ -e /tmp/fstab.bak ]] && mv -f /tmp/fstab /etc/fstab
+    rm -f /run/systemd/system/foo-*.mount
+    systemctl daemon-reload
+}
+
+trap at_exit EXIT
+
+# Check invalid characters directly in /proc/mountinfo
+#
+# This is a bit tricky (and hacky), since we have to temporarily replace
+# PID 1's /proc/mountinfo, but we have to keep the original mounts intact,
+# otherwise systemd would unmount them on reload
+TMP_MOUNTINFO="$(mktemp)"
+
+cp /proc/1/mountinfo "$TMP_MOUNTINFO"
+# Add a mount entry with a "Unicode non-character" in it
+echo -ne '69 1 252:2 / /foo/mountinfo rw,relatime shared:1 - cifs //foo\ufffebar rw,seclabel\n' >>"$TMP_MOUNTINFO"
+mount --bind "$TMP_MOUNTINFO" /proc/1/mountinfo
+systemctl daemon-reload
+# On affected versions this would throw an error:
+#   Failed to get properties: Bad message
+systemctl status foo-mountinfo.mount
+
+umount /proc/1/mountinfo
+systemctl daemon-reload
+rm -f "$TMP_MOUNTINFO"
+
+# Check invalid characters in a mount unit
+#
+# systemd already handles this and refuses to load the invalid string, e.g.:
+#   foo-fstab.mount:9: String is not UTF-8 clean, ignoring assignment: What=//localhost/foo���bar
+#
+# a) Unit generated from /etc/fstab
+[[ -e /etc/fstab ]] && cp -f /etc/fstab /tmp/fstab.bak
+
+echo -ne '//localhost/foo\ufffebar  /foo/fstab  cifs defaults 0 0\n' >/etc/fstab
+systemctl daemon-reload
+[[ "$(systemctl show -P UnitFileState foo-fstab.mount)" == bad ]]
+
+# b) Unit generated from /etc/fstab (but the invalid character is in options)
+echo -ne '//localhost/foobar  /foo/fstab/opt  cifs nosuid,a\ufffeb,noexec 0 0\n' >/etc/fstab
+systemctl daemon-reload
+[[ "$(systemctl show -P UnitFileState foo-fstab-opt.mount)" == bad ]]
+rm -f /etc/fstab
+
+[[ -e /tmp/fstab.bak ]] && mv -f /tmp/fstab /etc/fstab
+systemctl daemon-reload
+
+# c) Mount unit
+mkdir -p /run/systemd/system
+echo -ne '[Mount]\nWhat=//localhost/foo\ufffebar\nWhere=/foo/unit\nType=cifs\nOptions=noexec\n' >/run/systemd/system/foo-unit.mount
+systemctl daemon-reload
+[[ "$(systemctl show -P UnitFileState foo-unit.mount)" == bad ]]
+rm -f /run/systemd/system/foo-unit.mount
+
+# d) Mount unit (but the invalid character is in Options=)
+mkdir -p /run/systemd/system
+echo -ne '[Mount]\nWhat=//localhost/foobar\nWhere=/foo/unit/opt\nType=cifs\nOptions=noexec,a\ufffeb,nosuid\n' >/run/systemd/system/foo-unit-opt.mount
+systemctl daemon-reload
+[[ "$(systemctl show -P UnitFileState foo-unit-opt.mount)" == bad ]]
+rm -f /run/systemd/system/foo-unit-opt.mount


### PR DESCRIPTION


<!-- issue-commentator = {"comment-id":"3233437676"} -->