### PR TITLE
(RHEL-108568) fundamental: fix compile check for explicit_bzero

### DIFF
--- a/src/fundamental/memory-util-fundamental.h
+++ b/src/fundamental/memory-util-fundamental.h
@@ -11,7 +11,7 @@
 
 #include "macro-fundamental.h"
 
-#if defined(HAVE_EXPLICIT_BZERO)
+#if !defined(SD_BOOT) && HAVE_EXPLICIT_BZERO
 static inline void *explicit_bzero_safe(void *p, size_t l) {
         if (p && l > 0)
                 explicit_bzero(p, l);


### PR DESCRIPTION
Our HAVE_* variables are defined to 0 or 1, so '#if defined(HAVE_*)' is always true. The variable is not defined when compiling for EFI though, so we need the additional guard.

Fixup for 3f92dc2fd4070b213e6bc85263a9bef06ec9a486.

(I don't want to do something like add -DHAVE_EXPLICIT_BZERO=0 to the commandline in src/efi/boot/meson.build, because this quite verbose. Our compilation commandlines are very long already. Let's instead keep this localized in this one spot in the source file.)x

(cherry picked from commit 5deb391c6e6d2b8fd7b94234efea49cd6bee0d76)

Resolves: RHEL-108568

<!-- issue-commentator = {"comment-id":"3233578947"} -->