### PR TITLE
(RHEL-111065) journald: extend STDOUT_STREAMS_MAX to 64k

### DIFF
--- a/src/journal/journald-stream.c
+++ b/src/journal/journald-stream.c
@@ -38,7 +38,7 @@
 #include "unit-name.h"
 #include "user-util.h"
 
-#define STDOUT_STREAMS_MAX 4096
+#define STDOUT_STREAMS_MAX (64*1024)
 
 /* During the "setup" protocol phase of the stream logic let's define a different maximum line length than
  * during the actual operational phase. We want to allow users to specify very short line lengths after all,


### PR DESCRIPTION
Closes #35390.

(cherry picked from commit c576ba7182f54f352c03f0768c9178b173fb8bcb)

Resolves: RHEL-111065

<!-- issue-commentator = {"comment-id":"3242362095"} -->