### PR TITLE
(RHEL-114361) kernel-install: change space separation to '=' in argument of help message

### DIFF
--- a/src/kernel-install/kernel-install.in
+++ b/src/kernel-install/kernel-install.in
@@ -29,7 +29,7 @@ usage()
     echo "  kernel-install [OPTIONS...] remove KERNEL-VERSION [--entry-type...]"
     echo "  kernel-install [OPTIONS...] inspect"
     echo "Options:"
-    echo "  --entry-type type1|type2|all"
+    echo "  --entry-type=type1|type2|all"
     echo "                 Operate only on the specified bootloader entry type"
     echo "  -h, --help     Print this help and exit"
     echo "      --version  Print version string and exit"


### PR DESCRIPTION
This is a downstream-only fix as kernel-install diverted.

To be consistent in style in RHEL-10's systemd.
The call in kernel-core and kernel-uki-virt is also expecting this '='.

Fixes: a2d2e9bfc825c ("kernel-install: add --entry-type=type1|type2 option to kernel-install.in")
Signed-off-by: Li Tian <litian@redhat.com>

Resolves: RHEL-114361

<!-- issue-commentator = {"comment-id":"3283502440"} -->