### PR TITLE
(RHEL-109488) time-util: make USEC_TIMESTAMP_FORMATTABLE_MAX for 32bit system off b…

### DIFF
--- a/src/basic/time-util.h
+++ b/src/basic/time-util.h
@@ -200,13 +200,17 @@ static inline usec_t usec_sub_signed(usec_t timestamp, int64_t delta) {
         return usec_sub_unsigned(timestamp, (usec_t) delta);
 }
 
+/* The last second we can format is 31. Dec 9999, 1s before midnight, because otherwise we'd enter 5 digit
+ * year territory. However, since we want to stay away from this in all timezones we take one day off. */
+#define USEC_TIMESTAMP_FORMATTABLE_MAX_64BIT ((usec_t) 253402214399000000) /* Thu 9999-12-30 23:59:59 UTC */
+/* With a 32bit time_t we can't go beyond 2038...
+ * We parse timestamp with RFC-822/ISO 8601 (e.g. +06, or -03:00) as UTC, hence the upper bound must be off
+ * by USEC_PER_DAY. See parse_timestamp() for more details. */
+#define USEC_TIMESTAMP_FORMATTABLE_MAX_32BIT (((usec_t) INT32_MAX) * USEC_PER_SEC - USEC_PER_DAY)
 #if SIZEOF_TIME_T == 8
-  /* The last second we can format is 31. Dec 9999, 1s before midnight, because otherwise we'd enter 5 digit
-   * year territory. However, since we want to stay away from this in all timezones we take one day off. */
-#  define USEC_TIMESTAMP_FORMATTABLE_MAX ((usec_t) 253402214399000000)
+#  define USEC_TIMESTAMP_FORMATTABLE_MAX USEC_TIMESTAMP_FORMATTABLE_MAX_64BIT
 #elif SIZEOF_TIME_T == 4
-/* With a 32bit time_t we can't go beyond 2038... */
-#  define USEC_TIMESTAMP_FORMATTABLE_MAX ((usec_t) 2147483647000000)
+#  define USEC_TIMESTAMP_FORMATTABLE_MAX USEC_TIMESTAMP_FORMATTABLE_MAX_32BIT
 #else
 #  error "Yuck, time_t is neither 4 nor 8 bytes wide?"
 #endif

--- a/src/test/test-date.c
+++ b/src/test/test-date.c
@@ -104,8 +104,8 @@ int main(int argc, char *argv[]) {
         test_should_fail("9999-12-31 00:00:00 UTC");
         test_should_fail("10000-01-01 00:00:00 UTC");
 #elif SIZEOF_TIME_T == 4
-        test_should_pass("2038-01-19 03:14:07 UTC");
-        test_should_fail("2038-01-19 03:14:08 UTC");
+        test_should_pass("2038-01-18 03:14:07 UTC");
+        test_should_fail("2038-01-18 03:14:08 UTC");
 #endif
 
         return 0;

--- a/src/test/test-time-util.c
+++ b/src/test/test-time-util.c
@@ -550,7 +550,7 @@ TEST(format_timestamp_utc) {
         test_format_timestamp_utc_one(USEC_TIMESTAMP_FORMATTABLE_MAX, "Thu 9999-12-30 23:59:59 UTC");
         test_format_timestamp_utc_one(USEC_TIMESTAMP_FORMATTABLE_MAX + 1, "--- XXXX-XX-XX XX:XX:XX");
 #elif SIZEOF_TIME_T == 4
-        test_format_timestamp_utc_one(USEC_TIMESTAMP_FORMATTABLE_MAX, "Tue 2038-01-19 03:14:07 UTC");
+        test_format_timestamp_utc_one(USEC_TIMESTAMP_FORMATTABLE_MAX, "Mon 2038-01-18 03:14:07 UTC");
         test_format_timestamp_utc_one(USEC_TIMESTAMP_FORMATTABLE_MAX + 1, "--- XXXX-XX-XX XX:XX:XX");
 #endif
 


### PR DESCRIPTION
…y one day

As the same reason why we take one day off for 64bit case.

This also makes both upper bounds always defined for testing.

(cherry picked from commit bd5770da76ee157d3b31323ed2d22f5d9082bb36)

Related: RHEL-109488

---

We need this for the i686 builds that are automagically done in CS Koji, otherwise we sometimes generate a year 2038 timestamp that we then fail to process:

```
DEBUG: x: 2147440914849397; xx: Tue 2038-01-19 05:21:54 +14
src/test/test-time-util.c:392: Assertion failed: parse_timestamp(xx, &y): Invalid argument
Aborted (core dumped)
```

I let the test run for a while in an i686 mock chroot and the issue seems to be indeed gone (previously I always triggered it in less than 5 runs).

<!-- issue-commentator = {"comment-id":"3293142116"} -->