### PR TITLE
(RHEL-114974) basic: add PIDFS magic (#31709)

### DIFF
--- a/src/basic/filesystems-gperf.gperf
+++ b/src/basic/filesystems-gperf.gperf
@@ -91,6 +91,7 @@ ocfs2,           {OCFS2_SUPER_MAGIC}
 openpromfs,      {OPENPROM_SUPER_MAGIC}
 orangefs,        {ORANGEFS_DEVREQ_MAGIC}
 overlay,         {OVERLAYFS_SUPER_MAGIC}
+pidfs,           {PID_FS_MAGIC}
 pipefs,          {PIPEFS_MAGIC}
 ppc-cmm,         {PPC_CMM_MAGIC}
 proc,            {PROC_SUPER_MAGIC}

--- a/src/basic/missing_magic.h
+++ b/src/basic/missing_magic.h
@@ -128,6 +128,11 @@
 #define DEVMEM_MAGIC 0x454d444d
 #endif
 
+/* cb12fd8e0dabb9a1c8aef55a6a41e2c255fcdf4b (6.8) */
+#ifndef PID_FS_MAGIC
+#define PID_FS_MAGIC 0x50494446
+#endif
+
 /* Not in mainline but included in Ubuntu */
 #ifndef SHIFTFS_MAGIC
 #define SHIFTFS_MAGIC 0x6a656a62


### PR DESCRIPTION
Kernel commit cb12fd8e0dabb9a1c8aef55a6a41e2c255fcdf4b added pidfs. Update filesystems-gperf.gperf and missing_magic.h accordingly.

This fixes the following error building against a bleeding edge kernel.
```
../src/basic/meson.build:234:8: ERROR: Problem encountered: Unknown filesystems defined in kernel headers:

Filesystem found in kernel header but not in filesystems-gperf.gperf: PID_FS_MAGIC
```

(cherry picked from commit ed01b92e1c92871bbd92711f280e2b2d15753f0e)

Resolves: RHEL-114974

<!-- issue-commentator = {"comment-id":"3360652074"} -->