### PR TITLE
(RHEL-159230) manager: fix scope for environment generators

### DIFF
--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -3695,7 +3695,7 @@ static int manager_run_environment_generators(Manager *m) {
         if (MANAGER_IS_TEST_RUN(m) && !(m->test_run_flags & MANAGER_TEST_RUN_ENV_GENERATORS))
                 return 0;
 
-        paths = env_generator_binary_paths(MANAGER_IS_SYSTEM(m));
+        paths = env_generator_binary_paths(m->runtime_scope);
         if (!paths)
                 return log_oom();
 


### PR DESCRIPTION
fixes regression introduced by 4870133bfa

(cherry picked from commit 361cacf49e8fd6b0fc983f0ee507c1d22fa00103)

Resolves: RHEL-159230

<!-- issue-commentator = {"comment-id":"4117679744"} -->