### PR TITLE
(RHEL-166185) test: make test-fd-util more lenient when using fd_move_above_stdio()

### DIFF
--- a/src/test/test-fd-util.c
+++ b/src/test/test-fd-util.c
@@ -127,6 +127,7 @@ TEST(rearrange_stdio) {
 
         if (r == 0) {
                 _cleanup_free_ char *path = NULL;
+                int pipe_read_fd, pair[2];
                 char buffer[10];
 
                 /* Child */
@@ -134,6 +135,10 @@ TEST(rearrange_stdio) {
                 safe_close(STDERR_FILENO); /* Let's close an fd < 2, to make it more interesting */
 
                 assert_se(rearrange_stdio(-1, -1, -1) >= 0);
+                /* Reconfigure logging after rearranging stdout/stderr, so we still log to somewhere if the
+                 * following tests fail, making it slightly less annoying to debug */
+                log_set_target(LOG_TARGET_KMSG);
+                log_open();
 
                 assert_se(fd_get_path(STDIN_FILENO, &path) >= 0);
                 assert_se(path_equal(path, "/dev/null"));
@@ -151,13 +156,12 @@ TEST(rearrange_stdio) {
                 safe_close(STDOUT_FILENO);
                 safe_close(STDERR_FILENO);
 
-                {
-                        int pair[2];
-                        assert_se(pipe(pair) >= 0);
-                        assert_se(pair[0] == 0);
-                        assert_se(pair[1] == 1);
-                        assert_se(fd_move_above_stdio(0) == 3);
-                }
+                assert_se(pipe(pair) >= 0);
+                assert_se(pair[0] == 0);
+                assert_se(pair[1] == 1);
+                pipe_read_fd = fd_move_above_stdio(0);
+                assert_se(pipe_read_fd >= 3);
+
                 assert_se(open("/dev/full", O_WRONLY|O_CLOEXEC) == 0);
                 assert_se(acquire_data_fd("foobar", 6, 0) == 2);
 
@@ -165,7 +169,7 @@ TEST(rearrange_stdio) {
 
                 assert_se(write(1, "x", 1) < 0 && errno == ENOSPC);
                 assert_se(write(2, "z", 1) == 1);
-                assert_se(read(3, buffer, sizeof(buffer)) == 1);
+                assert_se(read(pipe_read_fd, buffer, sizeof(buffer)) == 1);
                 assert_se(buffer[0] == 'z');
                 assert_se(read(0, buffer, sizeof(buffer)) == 6);
                 assert_se(memcmp(buffer, "foobar", 6) == 0);
@@ -173,7 +177,7 @@ TEST(rearrange_stdio) {
                 assert_se(rearrange_stdio(-1, 1, 2) >= 0);
                 assert_se(write(1, "a", 1) < 0 && errno == ENOSPC);
                 assert_se(write(2, "y", 1) == 1);
-                assert_se(read(3, buffer, sizeof(buffer)) == 1);
+                assert_se(read(pipe_read_fd, buffer, sizeof(buffer)) == 1);
                 assert_se(buffer[0] == 'y');
 
                 assert_se(fd_get_path(0, &path) >= 0);


### PR DESCRIPTION
On s390x this test fails when the SUT uses the z90crypt kernel module,
as it's an another FD the test doesn't account for:

/* test_rearrange_stdio */
Successfully forked off 'rearrange' as PID 57293.
test_rearrange_stdio: r=0
/proc/57293/fd:
total 0
lrwx------. 1 root root 64 Apr  5 06:18 0 -> /dev/pts/0
lrwx------. 1 root root 64 Apr  5 06:18 1 -> /dev/pts/0
lrwx------. 1 root root 64 Apr  5 06:18 2 -> /dev/pts/0
lrwx------. 1 root root 64 Apr  5 06:18 3 -> /dev/z90crypt
rearrange terminated by signal ABRT.

Debugging this was pain, since the child process didn't log anything
once we closed stdout/stderr (for obvious reasons). Let's fix both
issues by switching logging to kmsg once we close stdin/stdout/stderr,
and also by making the test work fine when there are some extra FDs in
the child's environment.

(cherry picked from commit https://github.com/redhat-plumbers/systemd-rhel9/commit/a9805f8ca9c1561e373355fe7175579b31e1c08c)

---

This was merged to RHEL 9.8 in https://github.com/redhat-plumbers/systemd-rhel9/pull/373, but it fails on older releases as well, which is annoying. However, it's not annoying enough to deserve its own minor release, so let's pull this in with the next batch of fixes (if any) for RHEL 9.7.

<!-- issue-commentator = {"comment-id":"4135929552"} -->