### PR TITLE
(RHEL-163869) Add some hardening to config file parser in nspawn (9.7)

### DIFF
--- a/src/nspawn/nspawn-mount.c
+++ b/src/nspawn/nspawn-mount.c
@@ -1244,7 +1244,9 @@ int pivot_root_parse(char **pivot_root_new, char **pivot_root_old, const char *s
 
         if (!path_is_absolute(root_new))
                 return -EINVAL;
-        if (root_old && !path_is_absolute(root_old))
+        if (!path_is_normalized(root_new))
+                return -EINVAL;
+        if (root_old && (!path_is_absolute(root_old) || !path_is_normalized(root_old)))
                 return -EINVAL;
 
         free_and_replace(*pivot_root_new, root_new);

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -4304,8 +4304,13 @@ static int merge_settings(Settings *settings, const char *path) {
         }
 
         if ((arg_settings_mask & SETTING_EPHEMERAL) == 0 &&
-            settings->ephemeral >= 0)
-                arg_ephemeral = settings->ephemeral;
+            settings->ephemeral >= 0) {
+
+                if (!arg_settings_trusted)
+                        log_warning("Ignoring ephemeral setting, file %s is not trusted.", path);
+                else
+                        arg_ephemeral = settings->ephemeral;
+        }
 
         if ((arg_settings_mask & SETTING_DIRECTORY) == 0 &&
             settings->root) {
@@ -4473,8 +4478,13 @@ static int merge_settings(Settings *settings, const char *path) {
         }
 
         if ((arg_settings_mask & SETTING_BIND_USER) == 0 &&
-            !strv_isempty(settings->bind_user))
-                strv_free_and_replace(arg_bind_user, settings->bind_user);
+            !strv_isempty(settings->bind_user)) {
+
+                if (!arg_settings_trusted)
+                        log_warning("Ignoring bind user setting, file %s is not trusted.", path);
+                else
+                        strv_free_and_replace(arg_bind_user, settings->bind_user);
+        }
 
         if ((arg_settings_mask & SETTING_NOTIFY_READY) == 0 &&
             settings->notify_ready >= 0)


### PR DESCRIPTION
Resolves: RHEL-163869

<!-- issue-commentator = {"comment-id":"4214964264"} -->