### PR TITLE
(RHEL-163877) Add some hardening around attr. handling to various udev `*_id` tools

### DIFF
--- a/src/udev/dmi_memory_id/dmi_memory_id.c
+++ b/src/udev/dmi_memory_id/dmi_memory_id.c
@@ -50,6 +50,7 @@
 #include "string-util.h"
 #include "udev-util.h"
 #include "unaligned.h"
+#include "utf8.h"
 #include "version.h"
 
 #define SUPPORTED_SMBIOS_VER 0x030300
@@ -185,7 +186,7 @@ static void dmi_memory_device_string(
 
         str = strdupa_safe(dmi_string(h, s));
         str = strstrip(str);
-        if (!isempty(str))
+        if (!isempty(str) && utf8_is_valid(str) && !string_has_cc(str, /* ok= */ NULL))
                 printf("MEMORY_DEVICE_%u_%s=%s\n", slot_num, attr_suffix, str);
 }
 

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -443,7 +443,7 @@ static int scsi_id(char *maj_min_dev) {
                 if (dev_scsi.tgpt_group[0] != '\0')
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
                 if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
-                        printf("ID_SCSI_SERIAL=%s\n", serial_str);
+                        printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
                 goto out;
         }
 

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -389,6 +389,10 @@ static int set_inq_values(struct scsi_id_device *dev_scsi, const char *path) {
         return 0;
 }
 
+static bool scsi_string_is_valid(const char *s) {
+        return !isempty(s) && utf8_is_valid(s) && !string_has_cc(s, /* ok= */ NULL);
+}
+
 /*
  * scsi_id: try to get an id, if one is found, printf it to stdout.
  * returns a value passed to exit() - 0 if printed an id, else 1.
@@ -432,17 +436,17 @@ static int scsi_id(char *maj_min_dev) {
                         udev_replace_chars(serial_str, NULL);
                         printf("ID_SERIAL_SHORT=%s\n", serial_str);
                 }
-                if (dev_scsi.wwn[0] != '\0') {
+                if (scsi_string_is_valid(dev_scsi.wwn)) {
                         printf("ID_WWN=0x%s\n", dev_scsi.wwn);
-                        if (dev_scsi.wwn_vendor_extension[0] != '\0') {
+                        if (scsi_string_is_valid(dev_scsi.wwn_vendor_extension)) {
                                 printf("ID_WWN_VENDOR_EXTENSION=0x%s\n", dev_scsi.wwn_vendor_extension);
                                 printf("ID_WWN_WITH_EXTENSION=0x%s%s\n", dev_scsi.wwn, dev_scsi.wwn_vendor_extension);
                         } else
                                 printf("ID_WWN_WITH_EXTENSION=0x%s\n", dev_scsi.wwn);
                 }
-                if (dev_scsi.tgpt_group[0] != '\0')
+                if (scsi_string_is_valid(dev_scsi.tgpt_group))
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
-                if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
+                if (scsi_string_is_valid(dev_scsi.unit_serial_number))
                         printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
                 goto out;
         }

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -26,6 +26,7 @@
 #include "strv.h"
 #include "strxcpyx.h"
 #include "udev-util.h"
+#include "utf8.h"
 #include "version.h"
 
 static const struct option options[] = {
@@ -441,8 +442,8 @@ static int scsi_id(char *maj_min_dev) {
                 }
                 if (dev_scsi.tgpt_group[0] != '\0')
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
-                if (dev_scsi.unit_serial_number[0] != '\0')
-                        printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
+                if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
+                        printf("ID_SCSI_SERIAL=%s\n", serial_str);
                 goto out;
         }
 

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -39,6 +39,7 @@
 #include "strv.h"
 #include "strxcpyx.h"
 #include "udev-builtin.h"
+#include "utf8.h"
 
 #define ONBOARD_14BIT_INDEX_MAX ((1U << 14) - 1)
 #define ONBOARD_16BIT_INDEX_MAX ((1U << 16) - 1)
@@ -1188,9 +1189,13 @@ static int get_link_info(sd_device *dev, LinkInfo *info) {
                 return r;
 
         r = device_get_sysattr_value_filtered(dev, "phys_port_name", &info->phys_port_name);
-        if (r >= 0)
+        if (r >= 0) {
+                if (!utf8_is_valid(info->phys_port_name) || string_has_cc(info->phys_port_name, /* ok= */ NULL))
+                        return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
+
                 /* Check if phys_port_name indicates virtual device representor */
                 (void) sscanf(info->phys_port_name, "pf%*uvf%d", &info->vf_representor_id);
+        }
 
         r = device_get_sysattr_value_filtered(dev, "address", &s);
         if (r < 0 && r != -ENOENT)

--- a/src/udev/v4l_id/v4l_id.c
+++ b/src/udev/v4l_id/v4l_id.c
@@ -27,6 +27,8 @@
 #include <linux/videodev2.h>
 
 #include "fd-util.h"
+#include "string-util.h"
+#include "utf8.h"
 #include "util.h"
 
 int main(int argc, char *argv[]) {
@@ -66,7 +68,8 @@ int main(int argc, char *argv[]) {
         if (ioctl(fd, VIDIOC_QUERYCAP, &v2cap) == 0) {
                 int capabilities;
                 printf("ID_V4L_VERSION=2\n");
-                printf("ID_V4L_PRODUCT=%s\n", v2cap.card);
+                if (utf8_is_valid((char *)v2cap.card) && !string_has_cc((char *)v2cap.card, /* ok= */ NULL))
+                        printf("ID_V4L_PRODUCT=%s\n", v2cap.card);
                 printf("ID_V4L_CAPABILITIES=:");
                 if (v2cap.capabilities & V4L2_CAP_DEVICE_CAPS)
                         capabilities = v2cap.device_caps;


### PR DESCRIPTION
Resolves: RHEL-163877

<!-- issue-commentator = {"comment-id":"4223603245"} -->