### PR TITLE
(RHEL-127425) core: cleanup unit's dropin directories from global cache

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -603,6 +603,8 @@ static void unit_remove_transient(Unit *u) {
         if (!u->transient)
                 return;
 
+        const char *dropin_directory = strjoina(u->id, ".d");
+
         STRV_FOREACH(i, u->dropin_paths) {
                 _cleanup_free_ char *p = NULL, *pp = NULL;
 
@@ -615,6 +617,10 @@ static void unit_remove_transient(Unit *u) {
                 /* Only drop transient drop-ins */
                 if (!path_equal(u->manager->lookup_paths.transient, pp))
                         continue;
+
+                /* Drop the transient drop-in directory also from unit path cache. */
+                if (path_equal(last_path_component(p), dropin_directory))
+                        free(set_remove(u->manager->unit_path_cache, p));
 
                 (void) unlink(*i);
                 (void) rmdir(p);


### PR DESCRIPTION
When user creates dropin files via API (e.g. systemctl set-property ...) we put the dropin directory path into unit_path_cache. Drop those directories from the cache in unit_free() and prevent memory leak.

Follow-up for fce94c5c563b8f6ede2b8f7f283d2d2faff4e062.

Resolves: RHEL-127425

<!-- issue-commentator = {"comment-id":"4327355055"} -->