### PR TITLE
(RHEL-3631) udev: allow persistent storage rules for rbd devices

### DIFF
--- a/rules.d/60-block.rules
+++ b/rules.d/60-block.rules
@@ -9,5 +9,5 @@ ACTION=="change", SUBSYSTEM=="scsi", ENV{DEVTYPE}=="scsi_device", TEST=="block",
 
 # watch metadata changes, caused by tools closing the device node which was opened for writing
 ACTION!="remove", SUBSYSTEM=="block", \
-  KERNEL=="loop*|mmcblk*[0-9]|msblk*[0-9]|mspblk*[0-9]|nvme*|sd*|vd*|xvd*|bcache*|cciss*|dasd*|ubd*|ubi*|scm*|pmem*|nbd*|zd*", \
+  KERNEL=="loop*|mmcblk*[0-9]|msblk*[0-9]|mspblk*[0-9]|nvme*|sd*|vd*|xvd*|bcache*|cciss*|dasd*|ubd*|ubi*|scm*|pmem*|nbd*|zd*|rbd*", \
   OPTIONS+="watch"

--- a/rules.d/60-persistent-storage.rules
+++ b/rules.d/60-persistent-storage.rules
@@ -7,7 +7,7 @@ ACTION=="remove", GOTO="persistent_storage_end"
 ENV{UDEV_DISABLE_PERSISTENT_STORAGE_RULES_FLAG}=="1", GOTO="persistent_storage_end"
 
 SUBSYSTEM!="block|ubi", GOTO="persistent_storage_end"
-KERNEL!="loop*|mmcblk*[0-9]|msblk*[0-9]|mspblk*[0-9]|nvme*|sd*|sr*|vd*|xvd*|bcache*|cciss*|dasd*|ubd*|ubi*|scm*|pmem*|nbd*|zd*", GOTO="persistent_storage_end"
+KERNEL!="loop*|mmcblk*[0-9]|msblk*[0-9]|mspblk*[0-9]|nvme*|sd*|sr*|vd*|xvd*|bcache*|cciss*|dasd*|ubd*|ubi*|scm*|pmem*|nbd*|zd*|rbd*", GOTO="persistent_storage_end"
 
 # ignore partitions that span the entire disk
 TEST=="whole_disk", GOTO="persistent_storage_end"


### PR DESCRIPTION
The RADOS Block Device (rbd) can be used as any other block device with further layers on top of it, hence allow the common persistent storage rules to apply, including watching for changes.

(cherry picked from commit cbe65d38cf0a2e55cdba75871de108bc505a7095)

Resolves: RHEL-3631

<!-- issue-commentator = {"comment-id":"4341676759"} -->