### PR TITLE
(RHEL-180940) test: reenable test for cg_get_keyed_attribute()

### DIFF
--- a/src/test/test-cgroup-util.c
+++ b/src/test/test-cgroup-util.c
@@ -367,7 +367,7 @@ TEST(cg_get_keyed_attribute) {
         int i, r;
 
         r = cg_get_keyed_attribute("cpu", "/init.scope", "no_such_file", STRV_MAKE("no_such_attr"), &val);
-        if (IN_SET(r, -ENOMEDIUM, -ENOENT) || ERRNO_IS_PRIVILEGE(r)) {
+        if (r == -ENOMEDIUM || ERRNO_IS_PRIVILEGE(r)) {
                 log_info_errno(r, "Skipping most of %s, /sys/fs/cgroup not accessible: %m", __func__);
                 return;
         }


### PR DESCRIPTION
The test case was mistakenly disabled by
a412a1b92ab234a57c646f6779471772b2c355ec.

Co-authored-by: Natalie Vock <natalie.vock@gmx.de>
(cherry picked from commit 194e05642f74993d7be80724f2560f1a698931ec)

Resolves: RHEL-180940

<!-- issue-commentator = {"comment-id":"4991697402"} -->