### PR TITLE
(RHEL-155457) ci: bump the mkosi job to Ubuntu Noble

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,3 +35,4 @@ jobs:
           MULTI_STATUS: false
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GITHUB_ACTIONS: true
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@01d3218744765b55c3b5ffbb27e50961e50c33c5
+        uses: github/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918
         env:
           DEFAULT_BRANCH: main
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -32,5 +32,6 @@ jobs:
         uses: github/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918
         env:
           DEFAULT_BRANCH: main
+          MULTI_STATUS: false
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GITHUB_ACTIONS: true

--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -48,7 +48,7 @@ permissions:
 
 jobs:
   ci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.distro }}-${{ matrix.release }}-${{ github.ref }}
       cancel-in-progress: true
@@ -64,7 +64,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-    - uses: systemd/mkosi@070528fec478fc93af7ec057a5d2fd0045123c99
+    - uses: systemd/mkosi@857838464970f1092cc0107f4b1df714d0744990
 
     - name: Configure
       run: |

--- a/mkosi.images/initrd/mkosi.conf
+++ b/mkosi.images/initrd/mkosi.conf
@@ -8,7 +8,7 @@ Format=cpio
 
 [Content]
 BaseTrees=../../mkosi.output/base
-ExtraTrees=../../mkosi.output/base-systemd
+ExtraTrees=../../mkosi.output/systemd
 MakeInitrd=yes
 Bootable=no
 BuildPackages=

--- a/mkosi.images/system/mkosi.conf
+++ b/mkosi.images/system/mkosi.conf
@@ -9,7 +9,7 @@ Dependencies=base
 [Content]
 Autologin=yes
 BaseTrees=../../mkosi.output/base
-ExtraTrees=../../mkosi.output/base-systemd
+ExtraTrees=../../mkosi.output/systemd
 Packages=
         acl
         bash-completion

--- a/test/test-functions
+++ b/test/test-functions
@@ -1036,7 +1036,7 @@ install_iscsi() {
     # Install client-side stuff ("initiator" in iSCSI jargon) - Open-iSCSI in this case
     # (open-iscsi on Debian, iscsi-initiator-utils on Fedora, etc.)
     if [[ -z "$inst" || "$inst" =~ (client|initiator) ]]; then
-        image_install iscsi-iname iscsiadm iscsid iscsistart
+        image_install iscsi-iname iscsiadm iscsid iscsistart iscsi-gen-initiatorname
         image_install -o "${ROOTLIBDIR:?}"/system/iscsi-{init,onboot,shutdown}.service
         image_install "${ROOTLIBDIR:?}"/system/iscsid.{service,socket}
         image_install "${ROOTLIBDIR:?}"/system/iscsi.service


### PR DESCRIPTION
This should help with the missing pacman-package-manager package in the mkosi job.

rhel-only: ci
Related: RHEL-155457

<!-- issue-commentator = {"comment-id":"5024145201"} -->