### PR TITLE
(RHEL-50553) bus-util: Fix bus_log_connect_error()

### DIFF
--- a/src/shared/bus-util.c
+++ b/src/shared/bus-util.c
@@ -46,9 +46,9 @@ int bus_log_connect_error(int r, BusTransport transport) {
              hint_addr = transport == BUS_TRANSPORT_LOCAL && ERRNO_IS_PRIVILEGE(r);
 
         return log_error_errno(r,
-                               r == hint_vars ? "Failed to connect to bus: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined (consider using --machine=<user>@.host --user to connect to bus of other user)" :
-                               r == hint_addr ? "Failed to connect to bus: Operation not permitted (consider using --machine=<user>@.host --user to connect to bus of other user)" :
-                                                "Failed to connect to bus: %m");
+                               hint_vars ? "Failed to connect to bus: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined (consider using --machine=<user>@.host --user to connect to bus of other user)" :
+                               hint_addr ? "Failed to connect to bus: Operation not permitted (consider using --machine=<user>@.host --user to connect to bus of other user)" :
+                                           "Failed to connect to bus: %m");
 }
 
 int bus_async_unregister_and_exit(sd_event *e, sd_bus *bus, const char *name) {


### PR DESCRIPTION
(cherry picked from commit d64a5b30f10a07001c4124f5c4127452fc3cac99)

Resolves: RHEL-50553

<!-- issue-commentator = {"comment-id":"5353595095"} -->