### PR TITLE
(RHEL-33815) udev-node: optimize device node symlink creation

### DIFF
--- a/src/basic/locale-util.c
+++ b/src/basic/locale-util.c
@@ -17,6 +17,7 @@
 #include "fileio.h"
 #include "hashmap.h"
 #include "locale-util.h"
+#include "missing_syscall.h"
 #include "path-util.h"
 #include "set.h"
 #include "string-table.h"
@@ -294,6 +295,12 @@ bool is_locale_utf8(void) {
 
         if (cached_answer >= 0)
                 goto out;
+
+        /* This function may be called from libsystemd, and setlocale() is not thread safe. Assuming yes. */
+        if (gettid() != raw_getpid()) {
+                cached_answer = true;
+                goto out;
+        }
 
         if (!setlocale(LC_ALL, "")) {
                 cached_answer = true;

--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -467,13 +467,13 @@ static int link_update(sd_device *dev, const char *slink, bool add) {
                                 /* The devlink priority is downgraded. Another device may have a higher
                                  * priority now. Let's find the device node with the highest priority. */
                         } else {
-                                if (current_prio >= prio)
-                                        /* The devlink with equal or higher priority already exists and is
-                                         * owned by another device. Hence, it is not necessary to recreate it. */
+                                if (current_prio > prio)
+                                        /* The devlink with a higher priority already exists and is owned by
+                                         * another device. Hence, it is not necessary to recreate it. */
                                         return 0;
 
-                                /* This device has a higher priority than the current. Let's create the
-                                 * devlink to our device node. */
+                                /* This device has the equal or a higher priority than the current. Let's
+                                 * create the devlink to our device node. */
                                 return node_symlink(dev, NULL, slink);
                         }
 

--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -110,12 +110,14 @@ static int stack_directory_read_one(int dirfd, const char *id, char **devnode, i
 
         assert(dirfd >= 0);
         assert(id);
-        assert(devnode);
         assert(priority);
+
+        /* This reads priority and device node from the symlink under /run/udev/links (or udev database).
+         * If 'devnode' is NULL, obtained priority is always set to '*priority'. If 'devnode' is non-NULL,
+         * this updates '*devnode' and '*priority'. */
 
         /* First, let's try to read the entry with the new format, which should replace the old format pretty
          * quickly. */
-
         r = readlinkat_malloc(dirfd, id, &buf);
         if (r >= 0) {
                 char *colon;
@@ -139,6 +141,9 @@ static int stack_directory_read_one(int dirfd, const char *id, char **devnode, i
                 if (r < 0)
                         return r;
 
+                if (!devnode)
+                        goto finalize;
+
                 if (*devnode && tmp_prio <= *priority)
                         return 0; /* Unchanged */
 
@@ -160,6 +165,9 @@ static int stack_directory_read_one(int dirfd, const char *id, char **devnode, i
                 if (r < 0)
                         return r;
 
+                if (!devnode)
+                        goto finalize;
+
                 if (*devnode && tmp_prio <= *priority)
                         return 0; /* Unchanged */
 
@@ -174,6 +182,7 @@ static int stack_directory_read_one(int dirfd, const char *id, char **devnode, i
         } else
                 return r == -ENOENT ? -ENODEV : r;
 
+finalize:
         *priority = tmp_prio;
         return 1; /* Updated */
 }

--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -281,38 +281,6 @@ static int stack_directory_update(sd_device *dev, int fd, bool add) {
         return 1; /* Updated. */
 }
 
-static int stack_directory_open(const char *dirname) {
-        _cleanup_close_ int fd = -1;
-        int r;
-
-        assert(dirname);
-
-        r = mkdir_parents(dirname, 0755);
-        if (r < 0)
-                return r;
-
-        fd = open_mkdir_at(AT_FDCWD, dirname, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_RDONLY, 0755);
-        if (fd < 0)
-                return fd;
-
-        return TAKE_FD(fd);
-}
-
-static int stack_directory_lock(int dirfd) {
-        _cleanup_close_ int fd = -1;
-
-        assert(dirfd >= 0);
-
-        fd = openat(dirfd, ".lock", O_CLOEXEC | O_NOFOLLOW | O_RDONLY | O_CREAT, 0600);
-        if (fd < 0)
-                return -errno;
-
-        if (flock(fd, LOCK_EX) < 0)
-                return -errno;
-
-        return TAKE_FD(fd);
-}
-
 size_t udev_node_escape_path(const char *src, char *dest, size_t size) {
         size_t i, j;
         uint64_t h;
@@ -386,19 +354,14 @@ static int stack_directory_get_name(const char *slink, char **ret) {
         return 0;
 }
 
-static int stack_directory_open(sd_device *dev, const char *slink, int *ret_dirfd, int *ret_lockfd) {
+static int stack_directory_open(sd_device *dev, const char *dirname, int *ret_dirfd, int *ret_lockfd) {
         _cleanup_close_ int dirfd = -EBADF, lockfd = -EBADF;
-        _cleanup_free_ char *dirname = NULL;
         int r;
 
         assert(dev);
-        assert(slink);
+        assert(dirname);
         assert(ret_dirfd);
         assert(ret_lockfd);
-
-        r = stack_directory_get_name(slink, &dirname);
-        if (r < 0)
-                return log_device_debug_errno(dev, r, "Failed to build stack directory name for '%s': %m", slink);
 
         r = mkdir_parents(dirname, 0755);
         if (r < 0)
@@ -413,7 +376,7 @@ static int stack_directory_open(sd_device *dev, const char *slink, int *ret_dirf
                 return log_device_debug_errno(dev, errno, "Failed to create lock file for stack directory '%s': %m", dirname);
 
         if (flock(lockfd, LOCK_EX) < 0)
-                return log_device_debug_errno(dev, errno, "Failed to place a lock on lock file for %s: %m", dirname);
+                return log_device_debug_errno(dev, errno, "Failed to place a lock on lock file for '%s': %m", dirname);
 
         *ret_dirfd = TAKE_FD(dirfd);
         *ret_lockfd = TAKE_FD(lockfd);
@@ -422,7 +385,7 @@ static int stack_directory_open(sd_device *dev, const char *slink, int *ret_dirf
 
 static int link_update(sd_device *dev, const char *slink, bool add) {
         _cleanup_close_ int dirfd = -EBADF, lockfd = -EBADF;
-        _cleanup_free_ char *devnode = NULL;
+        _cleanup_free_ char *devnode = NULL, char *dirname = NULL;
         int r;
 
         assert(dev);
@@ -432,14 +395,7 @@ static int link_update(sd_device *dev, const char *slink, bool add) {
         if (r < 0)
                 return log_device_debug_errno(dev, r, "Failed to build stack directory name for '%s': %m", slink);
 
-        dirfd = stack_directory_open(dirname);
-        if (dirfd < 0)
-                return log_device_debug_errno(dev, dirfd, "Failed to open stack directory '%s': %m", dirname);
-
-        lockfd = stack_directory_lock(dirfd);
-        if (lockfd < 0)
-                return log_device_debug_errno(dev, lockfd, "Failed to lock stack directory '%s': %m", dirname);
-        r = stack_directory_open(dev, slink, &dirfd, &lockfd);
+        r = stack_directory_open(dev, dirname, &dirfd, &lockfd);
         if (r < 0)
                 return r;
 

--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -11,6 +11,7 @@
 #include "dirent-util.h"
 #include "escape.h"
 #include "fd-util.h"
+#include "fileio.h"
 #include "format-util.h"
 #include "fs-util.h"
 #include "hexdecoct.h"
@@ -175,14 +176,14 @@ static int stack_directory_read_one(int dirfd, const char *id, bool is_symlink, 
         return 1; /* Updated */
 }
 
-static int stack_directory_find_prioritized_devnode(sd_device *dev, const char *dirname, bool add, char **ret) {
+static int stack_directory_find_prioritized_devnode(sd_device *dev, int dirfd, bool add, char **ret) {
         _cleanup_closedir_ DIR *dir = NULL;
         _cleanup_free_ char *devnode = NULL;
         int r, priority = 0;
         const char *id;
 
         assert(dev);
-        assert(dirname);
+        assert(dirfd >= 0);
         assert(ret);
 
         /* Find device node of device with highest priority. This returns 1 if a device found, 0 if no
@@ -204,7 +205,7 @@ static int stack_directory_find_prioritized_devnode(sd_device *dev, const char *
                         return -ENOMEM;
         }
 
-        dir = opendir(dirname);
+        dir = xopendirat(dirfd, ".", O_NOFOLLOW);
         if (!dir)
                 return -errno;
 
@@ -223,9 +224,9 @@ static int stack_directory_find_prioritized_devnode(sd_device *dev, const char *
                 if (!IN_SET(de->d_type, DT_LNK, DT_REG))
                         continue;
 
-                r = stack_directory_read_one(dirfd(dir), de->d_name, /* is_symlink = */ de->d_type == DT_LNK, &devnode, &priority);
+                r = stack_directory_read_one(dirfd, de->d_name, /* is_symlink = */ de->d_type == DT_LNK, &devnode, &priority);
                 if (r < 0) {
-                        log_debug_errno(r, "Failed to read '%s/%s', ignoring: %m", dirname, de->d_name);
+                        log_debug_errno(r, "Failed to read '%s', ignoring: %m", de->d_name);
                         continue;
                 }
         }
@@ -385,9 +386,43 @@ static int stack_directory_get_name(const char *slink, char **ret) {
         return 0;
 }
 
+static int stack_directory_open(sd_device *dev, const char *slink, int *ret_dirfd, int *ret_lockfd) {
+        _cleanup_close_ int dirfd = -EBADF, lockfd = -EBADF;
+        _cleanup_free_ char *dirname = NULL;
+        int r;
+
+        assert(dev);
+        assert(slink);
+        assert(ret_dirfd);
+        assert(ret_lockfd);
+
+        r = stack_directory_get_name(slink, &dirname);
+        if (r < 0)
+                return log_device_debug_errno(dev, r, "Failed to build stack directory name for '%s': %m", slink);
+
+        r = mkdir_parents(dirname, 0755);
+        if (r < 0)
+                return log_device_debug_errno(dev, r, "Failed to create stack directory '%s': %m", dirname);
+
+        dirfd = open_mkdir_at(AT_FDCWD, dirname, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_RDONLY, 0755);
+        if (dirfd < 0)
+                return log_device_debug_errno(dev, dirfd, "Failed to open stack directory '%s': %m", dirname);
+
+        lockfd = openat(dirfd, ".lock", O_CLOEXEC | O_NOFOLLOW | O_RDONLY | O_CREAT, 0600);
+        if (lockfd < 0)
+                return log_device_debug_errno(dev, errno, "Failed to create lock file for stack directory '%s': %m", dirname);
+
+        if (flock(lockfd, LOCK_EX) < 0)
+                return log_device_debug_errno(dev, errno, "Failed to place a lock on lock file for %s: %m", dirname);
+
+        *ret_dirfd = TAKE_FD(dirfd);
+        *ret_lockfd = TAKE_FD(lockfd);
+        return 0;
+}
+
 static int link_update(sd_device *dev, const char *slink, bool add) {
-        _cleanup_free_ char *dirname = NULL, *devnode = NULL;
-        _cleanup_close_ int dirfd = -1, lockfd = -1;
+        _cleanup_close_ int dirfd = -EBADF, lockfd = -EBADF;
+        _cleanup_free_ char *devnode = NULL;
         int r;
 
         assert(dev);
@@ -404,12 +439,15 @@ static int link_update(sd_device *dev, const char *slink, bool add) {
         lockfd = stack_directory_lock(dirfd);
         if (lockfd < 0)
                 return log_device_debug_errno(dev, lockfd, "Failed to lock stack directory '%s': %m", dirname);
+        r = stack_directory_open(dev, slink, &dirfd, &lockfd);
+        if (r < 0)
+                return r;
 
         r = stack_directory_update(dev, dirfd, add);
         if (r < 0)
-                return log_device_debug_errno(dev, r, "Failed to update stack directory '%s': %m", dirname);
+                return log_device_debug_errno(dev, r, "Failed to update stack directory for '%s': %m", slink);
 
-        r = stack_directory_find_prioritized_devnode(dev, dirname, add, &devnode);
+        r = stack_directory_find_prioritized_devnode(dev, dirfd, add, &devnode);
         if (r < 0)
                 return log_device_debug_errno(dev, r, "Failed to determine device node with the highest priority for '%s': %m", slink);
         if (r > 0)

--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -378,10 +378,42 @@ static int stack_directory_open(sd_device *dev, const char *dirname, int *ret_di
         return 0;
 }
 
-static int link_update(sd_device *dev, const char *slink, bool add) {
-        _cleanup_close_ int dirfd = -EBADF, lockfd = -EBADF;
-        _cleanup_free_ char *devnode = NULL, char *dirname = NULL;
+static int node_get_current(const char *slink, int dirfd, char **ret_id, int *ret_prio) {
+        _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
+        _cleanup_free_ char *id_dup = NULL;
+        const char *id;
         int r;
+
+        assert(slink);
+        assert(dirfd >= 0);
+        assert(ret_id);
+
+        r = sd_device_new_from_devname(&dev, slink);
+        if (r < 0)
+                return r;
+
+        r = device_get_device_id(dev, &id);
+        if (r < 0)
+                return r;
+
+        id_dup = strdup(id);
+        if (!id_dup)
+                return -ENOMEM;
+
+        if (ret_prio) {
+                r = stack_directory_read_one(dirfd, id, NULL, ret_prio);
+                if (r < 0)
+                        return r;
+        }
+
+        *ret_id = TAKE_PTR(id_dup);
+        return 0;
+}
+
+static int link_update(sd_device *dev, const char *slink, bool add) {
+        _cleanup_free_ char *current_id = NULL, *devnode = NULL, *dirname = NULL;
+        _cleanup_close_ int dirfd = -EBADF, lockfd = -EBADF;
+        int r, current_prio;
 
         assert(dev);
         assert(slink);
@@ -394,9 +426,63 @@ static int link_update(sd_device *dev, const char *slink, bool add) {
         if (r < 0)
                 return r;
 
+        r = node_get_current(slink, dirfd, &current_id, add ? &current_prio : NULL);
+        if (r < 0 && !ERRNO_IS_DEVICE_ABSENT(r))
+                return log_device_debug_errno(dev, r, "Failed to get the current device node priority for '%s': %m", slink);
+
         r = stack_directory_update(dev, dirfd, add);
         if (r < 0)
                 return log_device_debug_errno(dev, r, "Failed to update stack directory for '%s': %m", slink);
+
+        if (current_id) {
+                const char *id;
+
+                r = device_get_device_id(dev, &id);
+                if (r < 0)
+                        return log_device_debug_errno(dev, r, "Failed to get device id: %m");
+
+                if (add) {
+                        int prio;
+
+                        r = device_get_devlink_priority(dev, &prio);
+                        if (r < 0)
+                                return log_device_debug_errno(dev, r, "Failed to get devlink priority: %m");
+
+                        if (streq(current_id, id)) {
+                                if (current_prio <= prio)
+                                        /* The devlink is ours and already exists, and the new priority is
+                                         * equal or higher than the previous. Hence, it is not necessary to
+                                         * recreate it. */
+                                        return 0;
+
+                                /* The devlink priority is downgraded. Another device may have a higher
+                                 * priority now. Let's find the device node with the highest priority. */
+                        } else {
+                                if (current_prio >= prio)
+                                        /* The devlink with equal or higher priority already exists and is
+                                         * owned by another device. Hence, it is not necessary to recreate it. */
+                                        return 0;
+
+                                /* This device has a higher priority than the current. Let's create the
+                                 * devlink to our device node. */
+                                return node_symlink(dev, NULL, slink);
+                        }
+
+                } else {
+                        if (!streq(current_id, id))
+                                /* The devlink already exists and is owned by another device. Hence, it is
+                                 * not necessary to recreate it. */
+                                return 0;
+
+                        /* The current devlink is ours, and the target device will be removed. Hence, we need
+                         * to search the device that has the highest priority. and update the devlink. */
+                }
+        } else {
+                /* The requested devlink does not exist, or the target device does not exist and the devlink
+                 * points to a non-existing device. Let's search the deivce that has the highest priority,
+                 * and update the devlink. */
+                ;
+        }
 
         r = stack_directory_find_prioritized_devnode(dev, dirfd, add, &devnode);
         if (r < 0)


### PR DESCRIPTION
If multiple devices requested the same device node symlink with the same
priority, then previously we read O(N^2) of files saved in
/run/udev/links.

This makes if the requested symlink already exists with equal or higher
priority, then the symlink is kept, and skip to read all existing files,
except for one related to the current device node, in /run/udev/links.
Hence, the total amount of file read becomes O(N).

This improves performance of testcase_simultaneous_events_2 added by the
previous commit about 30%.
Before (32.8 sec):
```
 ## 3 iterations start: 11:13:44.690953163
 ## 3 iterations end: 11:14:17.493974927
```
After (23.8 sec):
```
 ## 3 iterations start: 11:17:53.869938387
 ## 3 iterations end: 11:18:17.624268345
```

This is based on the idea and analysis by Franck Bui.

Replaces #25839.

Co-authored-by: Franck Bui <fbui@suse.com>
(cherry picked from commit 331aa7aa15ee5dd12b369b276f575d521435eb52)

Resolves: RHEL-33815

<!-- issue-commentator = {"comment-id":"5327246573"} -->